### PR TITLE
Development/sanghwa pay

### DIFF
--- a/pay/build.gradle
+++ b/pay/build.gradle
@@ -18,12 +18,17 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 test {

--- a/pay/src/main/java/com/zerobase/config/Constants.java
+++ b/pay/src/main/java/com/zerobase/config/Constants.java
@@ -1,0 +1,20 @@
+package com.zerobase.config;
+
+public final class Constants {
+
+    // Prevent instantiation
+    private Constants() {}
+
+    // KakaoPay constants
+    public static final String KAKAO_CID = "TC0ONETIME";
+    public static final String KAKAO_APPROVAL_URL = "http://localhost:8080";
+    public static final String KAKAO_FAIL_URL = "http://localhost:8080";
+    public static final String KAKAO_CANCEL_URL = "http://localhost:8080";
+
+    // DepositService constants
+    public static final String ITEM_NAME = "여행참여 보증금";
+    public static final int QUANTITY = 1;
+    public static final int DEPOSIT_AMOUNT = 100_000;
+    public static final int TAX_FREE_AMOUNT = DEPOSIT_AMOUNT / 11;
+
+}

--- a/pay/src/main/java/com/zerobase/controller/PayController.java
+++ b/pay/src/main/java/com/zerobase/controller/PayController.java
@@ -1,0 +1,79 @@
+package com.zerobase.controller;
+
+import com.zerobase.model.RequestReadyPayDeposit;
+import com.zerobase.model.type.ResponseDepositPayDto;
+import com.zerobase.service.PayManagmentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/*
+ 페이서비스에 결제 준비를 요청 -> client 결제정보 수신
+ -> client 성공, 실패, 취소에 따라 서로다른 URL 로 연결됨.
+ */
+@RestController
+@RequestMapping(value = "/pay")
+@RequiredArgsConstructor
+@Slf4j
+public class PayController {
+
+    private final PayManagmentService payManagmentService;
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/ready")
+    public ResponseEntity<ResponseDepositPayDto> readyPayDeposit(
+        @RequestBody RequestReadyPayDeposit request) {
+        log.info("request ready pay deposit {}", request.toString());
+        return ResponseEntity.ok(payManagmentService.readyDepositPay(
+            request.getPostId(),
+            request.getParticipationId(), request.getUserId(),
+            request.getPaymentMethod()))
+            ;
+
+    }
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/success")
+    public ResponseEntity<Object> CreatePayDepositSuccess() {
+
+        return null;
+    }
+
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/fail")
+    public ResponseEntity<Object> CreatePayDepositFail() {
+
+        return null;
+    }
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/refund")
+    public ResponseEntity<Object> CreatePayDepositCancel() {
+
+        return null;
+    }
+
+
+    @GetMapping(value = "/deposit")
+    public ResponseEntity<Object> getPayDeposit(
+        @RequestParam String userId, @RequestParam Long postId) {
+
+        return null;
+    }
+
+    @GetMapping
+    public ResponseEntity<Object> getPayHistory() {
+
+        return null;
+    }
+
+
+}

--- a/pay/src/main/java/com/zerobase/entity/DepositEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/DepositEntity.java
@@ -1,0 +1,35 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PaymentMethod;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    // 후속 보충 데이터
+    private String payKey;
+    private Integer amount;
+    private PaymentMethod paymentMethod;
+    // 변경 데이터
+    private DepositStatus depositStatus;
+}

--- a/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
@@ -1,0 +1,34 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.KaKaoPayStatus;
+import com.zerobase.model.type.KaoKaoPayMethod;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoPayPaymentHistoryEntity {
+
+    @Id
+    private Long KakaoPayPaymentHistoryId;
+    private String paymentId;
+    @OneToOne
+    private PaymentHistoryEntity paymentHistoryEntity;
+    private Long userId;
+    private String tid;
+    private String partnerOrderId;
+    private String partnerUserId;
+    private KaKaoPayStatus kaKaoStatus;
+    private KaoKaoPayMethod kaoKaoPayMethod;
+
+}

--- a/pay/src/main/java/com/zerobase/entity/PaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentHistoryEntity.java
@@ -1,0 +1,36 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.PaymentMethod;
+import com.zerobase.model.type.PaymentStatus;
+import com.zerobase.model.type.TransactionType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentHistoryId;
+    private Long userId;
+    private Long amount;
+    private PaymentStatus paymentStatus;
+    private PaymentMethod paymentMethod;
+    // 여기서는 deposit
+    private TransactionType referencialTransactionType;
+    // 여기서는 현재, deposit_id
+    private Long referencialOrderId;
+
+}

--- a/pay/src/main/java/com/zerobase/model/DepositDto.java
+++ b/pay/src/main/java/com/zerobase/model/DepositDto.java
@@ -1,0 +1,37 @@
+package com.zerobase.model;
+
+import com.zerobase.entity.DepositEntity;
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PaymentMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositDto {
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    private Integer amount;
+    private PaymentMethod paymentMethod;
+    private DepositStatus depositStatus;
+
+    public static DepositDto fromEntity(DepositEntity entity) {
+        return DepositDto.builder()
+            .depositId(entity.getDepositId())
+            .postId(entity.getPostId())
+            .participationId(entity.getParticipationId())
+            .userId(entity.getUserId())
+            .amount(entity.getAmount())
+            .paymentMethod(entity.getPaymentMethod())
+            .depositStatus(entity.getDepositStatus())
+            .build();
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/DepositInitialDto.java
+++ b/pay/src/main/java/com/zerobase/model/DepositInitialDto.java
@@ -1,0 +1,37 @@
+package com.zerobase.model;
+
+import com.zerobase.entity.DepositEntity;
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PaymentMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DepositInitialDto {
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    private Integer amount;
+    private PaymentMethod paymentMethod;
+    private DepositStatus depositStatus;
+
+    public static DepositInitialDto fromEntity(DepositEntity entity){
+        return DepositInitialDto.builder()
+            .depositId(entity.getDepositId())
+            .postId(entity.getPostId())
+            .participationId(entity.getParticipationId())
+            .userId(entity.getUserId())
+            .amount(entity.getAmount())
+            .paymentMethod(entity.getPaymentMethod())
+            .depositStatus(entity.getDepositStatus())
+            .build();
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/PayApiDto.java
+++ b/pay/src/main/java/com/zerobase/model/PayApiDto.java
@@ -1,0 +1,17 @@
+package com.zerobase.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PayApiDto {
+    private String tid;
+    private String next_redirect_pc_url;
+}

--- a/pay/src/main/java/com/zerobase/model/RequestPayAPiDto.java
+++ b/pay/src/main/java/com/zerobase/model/RequestPayAPiDto.java
@@ -1,0 +1,44 @@
+package com.zerobase.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestPayAPiDto {
+    private String cid;
+
+    @JsonProperty("partner_order_id")
+    private String partnerOrderId;
+
+    @JsonProperty("partner_user_id")
+    private String partnerUserId;
+
+    @JsonProperty("item_name")
+    private String itemName;
+
+    @JsonProperty("quantity")
+    private String quantity;
+
+    @JsonProperty("total_amount")
+    private String totalAmount;
+
+    @JsonProperty("tax_free_amount")
+    private String taxFreeAmount;
+
+    @JsonProperty("approval_url")
+    private  String approvalUrl;
+
+    @JsonProperty("cancel_url")
+    private  String cancelUrl;
+
+    @JsonProperty("fail_url")
+    private  String failUrl;
+}

--- a/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
+++ b/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
@@ -1,0 +1,20 @@
+package com.zerobase.model;
+
+import com.zerobase.model.type.PaymentMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestReadyPayDeposit {
+    Long postId;
+    Long participationId;
+    String userId;
+    PaymentMethod paymentMethod;
+}

--- a/pay/src/main/java/com/zerobase/model/type/DepositStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/DepositStatus.java
@@ -1,0 +1,7 @@
+package com.zerobase.model.type;
+
+public enum DepositStatus {
+    PAID,
+    REFUNDED,
+    IN_PROGRESS
+}

--- a/pay/src/main/java/com/zerobase/model/type/KaKaoPayStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/KaKaoPayStatus.java
@@ -1,0 +1,4 @@
+package com.zerobase.model.type;
+
+public enum KaKaoPayStatus {
+}

--- a/pay/src/main/java/com/zerobase/model/type/PaymentStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/PaymentStatus.java
@@ -1,0 +1,11 @@
+package com.zerobase.model.type;
+
+public enum PaymentStatus {
+    PAY_IN_PROGRESS,
+    PAY_COMPLETED,
+    PAY_FAILED,
+    PAY_REFUNDED
+}
+
+
+

--- a/pay/src/main/java/com/zerobase/model/type/ResponseDepositPayDto.java
+++ b/pay/src/main/java/com/zerobase/model/type/ResponseDepositPayDto.java
@@ -1,0 +1,41 @@
+package com.zerobase.model.type;
+
+import com.zerobase.model.DepositInitialDto;
+import com.zerobase.model.PayApiDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseDepositPayDto {
+
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    private Integer amount;
+    private PaymentMethod paymentMethod;
+    private DepositStatus depositStatus;
+    private String next_redirect_pc_url;
+
+    public static ResponseDepositPayDto fromDepositInitialDtoAndpayApiDto
+        (DepositInitialDto depositInitialDto, PayApiDto payApiDto) {
+        return ResponseDepositPayDto.builder()
+            .depositId(depositInitialDto.getDepositId())
+            .postId(depositInitialDto.getPostId())
+            .participationId(depositInitialDto.getParticipationId())
+            .userId(depositInitialDto.getUserId())
+            .amount(depositInitialDto.getAmount())
+            .paymentMethod(depositInitialDto.getPaymentMethod())
+            .depositStatus(depositInitialDto.getDepositStatus())
+            .next_redirect_pc_url(payApiDto.getNext_redirect_pc_url())
+            .build();
+
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/type/TransactionType.java
+++ b/pay/src/main/java/com/zerobase/model/type/TransactionType.java
@@ -1,0 +1,5 @@
+package com.zerobase.model.type;
+
+public enum TransactionType {
+    DEPOSIT_TRANSACTION,
+}

--- a/pay/src/main/java/com/zerobase/service/ApiService.java
+++ b/pay/src/main/java/com/zerobase/service/ApiService.java
@@ -1,0 +1,10 @@
+package com.zerobase.service;
+
+import com.zerobase.model.PayApiDto;
+
+public interface ApiService {
+
+    public PayApiDto getReady(Long orderId, String userId);
+
+
+}

--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -1,0 +1,59 @@
+package com.zerobase.service;
+
+import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
+
+import com.zerobase.entity.DepositEntity;
+import com.zerobase.model.DepositDto;
+import com.zerobase.model.DepositInitialDto;
+import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PaymentMethod;
+import com.zerobase.repository.DepositRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class DepositService {
+
+    private final DepositRepository depositRepository;
+
+
+
+
+
+    // depositId를 생성하기 위해서
+    public DepositInitialDto initialSave(Long postId, Long participationId,
+        String userId, String payKey, PaymentMethod paymentMethod) {
+        log.info("DepositRepository initial save start");
+
+        DepositEntity depositEntity = DepositEntity.builder()
+            .postId(postId)
+            .participationId(participationId)
+            .userId(userId)
+            .paymentMethod(paymentMethod)
+            .payKey(payKey)
+            .amount(DEPOSIT_AMOUNT)
+            .depositStatus(DepositStatus.IN_PROGRESS)
+            .build();
+
+        return DepositInitialDto.fromEntity(depositRepository.save(depositEntity));
+    }
+
+    public DepositDto updateAfterPaySuccess(Long depositId, String payKey) {
+
+        DepositEntity depositEntity = depositRepository.findById(depositId)
+            .orElseThrow(() -> new CustomException());
+
+        depositEntity.setPayKey(payKey);
+        depositEntity.setDepositStatus(DepositStatus.PAID);
+
+        return DepositDto.fromEntity(depositRepository.save(depositEntity));
+    }
+
+
+}

--- a/pay/src/main/java/com/zerobase/service/KakaopayApiService.java
+++ b/pay/src/main/java/com/zerobase/service/KakaopayApiService.java
@@ -1,0 +1,65 @@
+package com.zerobase.service;
+
+import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
+import static com.zerobase.config.Constants.ITEM_NAME;
+import static com.zerobase.config.Constants.QUANTITY;
+import static com.zerobase.config.Constants.TAX_FREE_AMOUNT;
+
+import com.zerobase.model.PayApiDto;
+import com.zerobase.model.RequestPayAPiDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class KakaopayApiService implements ApiService {
+
+    @Value("${paymentMethod.kakaopay.secretkey-dev}")
+    private String SECRET_KEY;
+
+    private static final String MOCK_CID = "TC0ONETIME";
+
+
+
+    @Override
+    public PayApiDto getReady(Long orderId, String userId) {
+        log.info("KakaopayApiService getReady");
+        // webclient url, header입력
+        WebClient webclient = WebClient.builder()
+            .baseUrl("https://open-api.kakaopay.com")
+            .defaultHeader("Content-Type", "application/json")
+            .defaultHeader("Authorization", "SECRET_KEY "+ SECRET_KEY)
+            .build();
+
+        RequestPayAPiDto requestPayApiDto = RequestPayAPiDto.builder()
+            .cid(MOCK_CID)
+            .partnerOrderId(String.valueOf(orderId))
+            .partnerUserId(userId)
+            .itemName(ITEM_NAME)
+            .quantity(String.valueOf(QUANTITY))
+            .totalAmount(String.valueOf(DEPOSIT_AMOUNT))
+            .taxFreeAmount(String.valueOf(TAX_FREE_AMOUNT))
+            .approvalUrl(PayManagmentService.APPROVAL_URL)
+            .cancelUrl(PayManagmentService.CANCEL_URL)
+            .failUrl(PayManagmentService.FAIL_URL)
+            .build();
+        //
+        PayApiDto payApiDto = webclient.post()
+            .uri("/online/v1/payment/ready")
+            .bodyValue(
+                requestPayApiDto
+            )
+            .retrieve()
+            .bodyToMono(PayApiDto.class)
+            .block();
+
+        return payApiDto;
+    }
+}
+
+
+

--- a/pay/src/main/java/com/zerobase/service/PayManagmentService.java
+++ b/pay/src/main/java/com/zerobase/service/PayManagmentService.java
@@ -1,0 +1,41 @@
+package com.zerobase.service;
+
+import com.zerobase.model.DepositInitialDto;
+import com.zerobase.model.PayApiDto;
+import com.zerobase.model.type.PaymentMethod;
+import com.zerobase.model.type.ResponseDepositPayDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PayManagmentService {
+
+    private final DepositService depositService;
+    private final KakaopayApiService kakaopayApiService;
+
+    public static final String APPROVAL_URL = "http://localhost:8080";
+    public static final String FAIL_URL = "http://localhost:8080";
+    public static final String CANCEL_URL = "http://localhost:8080";
+
+
+
+
+    @Transactional
+    public ResponseDepositPayDto readyDepositPay(
+        Long postId, Long participationId, String userId,
+        PaymentMethod paymentMethod) {
+        log.info("readyDepositPay");
+
+        PayApiDto payApiDto = kakaopayApiService.getReady( participationId, userId);
+        DepositInitialDto depositInitialDto = depositService.initialSave(postId,
+            participationId, userId, payApiDto.getTid(), paymentMethod);
+
+        return ResponseDepositPayDto.fromDepositInitialDtoAndpayApiDto
+                (depositInitialDto, payApiDto);
+    }
+
+}

--- a/pay/src/main/resources/application.yaml
+++ b/pay/src/main/resources/application.yaml
@@ -1,0 +1,31 @@
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled : true
+      path: /h2-console
+  jpa:
+    defer-datasource-initialization : false
+    database-platform : org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+
+    properties :
+      hibernate :
+        format_sql: true
+        show_sql : true
+
+deposit:
+  amount : 100_000
+
+paymentMethod:
+  kakaopay:
+    secretkey-dev : "DEVBB2EC55AEA5209485B283C6EAC15502C4B307"
+
+

--- a/travel/src/main/java/com/zerobase/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/controller/CommunityController.java
@@ -1,9 +1,9 @@
-package com.zerobase.communities.controller;
+package com.zerobase.controller;
 
-import com.zerobase.communities.service.CommunityManagementService;
-import com.zerobase.communities.type.RequestCreateCommunity;
-import com.zerobase.communities.type.RequestPostCommunity;
-import com.zerobase.communities.type.ResponseCommunityDto;
+import com.zerobase.service.CommunityManagementService;
+import com.zerobase.model.RequestCreateCommunity;
+import com.zerobase.model.RequestPostCommunity;
+import com.zerobase.model.ResponseCommunityDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;

--- a/travel/src/main/java/com/zerobase/entity/CommunityEntity.java
+++ b/travel/src/main/java/com/zerobase/entity/CommunityEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.entity;
+package com.zerobase.entity;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;

--- a/travel/src/main/java/com/zerobase/entity/CommunityFileEntity.java
+++ b/travel/src/main/java/com/zerobase/entity/CommunityFileEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.entity;
+package com.zerobase.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/travel/src/main/java/com/zerobase/model/CommunityDto.java
+++ b/travel/src/main/java/com/zerobase/model/CommunityDto.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
-import com.zerobase.communities.entity.CommunityEntity;
+import com.zerobase.entity.CommunityEntity;
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
 import lombok.Builder;

--- a/travel/src/main/java/com/zerobase/model/CommunityFileDto.java
+++ b/travel/src/main/java/com/zerobase/model/CommunityFileDto.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
-import com.zerobase.communities.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityFileEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/travel/src/main/java/com/zerobase/model/RequestCreateCommunity.java
+++ b/travel/src/main/java/com/zerobase/model/RequestCreateCommunity.java
@@ -1,8 +1,7 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -11,11 +10,8 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RequestPostCommunity {
+public class RequestCreateCommunity {
 
-
-    @Min(1)
-    long communityId;
     @NotNull
     Continent continent;
     @NotNull

--- a/travel/src/main/java/com/zerobase/model/RequestPostCommunity.java
+++ b/travel/src/main/java/com/zerobase/model/RequestPostCommunity.java
@@ -1,7 +1,8 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -10,8 +11,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RequestCreateCommunity {
+public class RequestPostCommunity {
 
+
+    @Min(1)
+    long communityId;
     @NotNull
     Continent continent;
     @NotNull

--- a/travel/src/main/java/com/zerobase/model/ResponseCommunityDto.java
+++ b/travel/src/main/java/com/zerobase/model/ResponseCommunityDto.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;

--- a/travel/src/main/java/com/zerobase/model/type/CustomException.java
+++ b/travel/src/main/java/com/zerobase/model/type/CustomException.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model.type;
 
 
 import lombok.AllArgsConstructor;

--- a/travel/src/main/java/com/zerobase/model/type/ErrorCode.java
+++ b/travel/src/main/java/com/zerobase/model/type/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model.type;
 
 public enum ErrorCode {
     COMMUNITY_NON_EXISTENT

--- a/travel/src/main/java/com/zerobase/repository/CommunityFileRepository.java
+++ b/travel/src/main/java/com/zerobase/repository/CommunityFileRepository.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.repository;
+package com.zerobase.repository;
 
-import com.zerobase.communities.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityFileEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/travel/src/main/java/com/zerobase/repository/CommunityRepository.java
+++ b/travel/src/main/java/com/zerobase/repository/CommunityRepository.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.repository;
+package com.zerobase.repository;
 
-import com.zerobase.communities.entity.CommunityEntity;
+import com.zerobase.entity.CommunityEntity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/travel/src/main/java/com/zerobase/service/CommunityFileService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityFileService.java
@@ -1,9 +1,9 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.entity.CommunityEntity;
-import com.zerobase.communities.entity.CommunityFileEntity;
-import com.zerobase.communities.repository.CommunityFileRepository;
-import com.zerobase.communities.type.CommunityFileDto;
+import com.zerobase.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityEntity;
+import com.zerobase.repository.CommunityFileRepository;
+import com.zerobase.model.CommunityFileDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/travel/src/main/java/com/zerobase/service/CommunityManagementService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityManagementService.java
@@ -1,15 +1,13 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.type.CommunityDto;
-import com.zerobase.communities.type.CommunityFileDto;
-import com.zerobase.communities.type.RequestCreateCommunity;
-import com.zerobase.communities.type.RequestPostCommunity;
-import com.zerobase.communities.type.ResponseCommunityDto;
-import java.util.ArrayList;
+import com.zerobase.model.CommunityDto;
+import com.zerobase.model.CommunityFileDto;
+import com.zerobase.model.RequestCreateCommunity;
+import com.zerobase.model.RequestPostCommunity;
+import com.zerobase.model.ResponseCommunityDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,25 +20,29 @@ public class CommunityManagementService {
     private final CommunityFileService communityFileService;
 
 
-    // 포스트 생성
+    // 단건 포스트 생성
     @Transactional
     public ResponseCommunityDto createPost(RequestCreateCommunity request) {
 
+        // request에서 필요한 정보만 넘겨서 post생성
         CommunityDto communityDto = communityService.createPost(
             request.getContinent(),request.getCountry(),request.getRegion(),
             request.getTitle(),request.getContent());
 
+        // 부모 테이블에서 communityId를 추출하고 file list 정보를 추출하여 첨부파일 맵핑
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
 
         return ResponseCommunityDto.fromEntity(communityDto, communityFileDtos);
     }
 
-    //다건 조회
+    //다건 조회 ; 페이징처리
     public Page<ResponseCommunityDto> getPosts(Pageable pageable) {
 
+        // 페이징에 따른 포스트 리스트 조회
         Page<CommunityDto> communityDtos = communityService.getPosts(pageable);
 
+        // 포스트 리스트에 해당하는 첨부파일 리스트를 조회
         Page<ResponseCommunityDto> responseCommunityDtos = communityDtos.map(e
             -> ResponseCommunityDto.fromEntity(e,
             communityFileService.getFiles(e.getCommunityId())));
@@ -50,7 +52,9 @@ public class CommunityManagementService {
 
     // 단건조회
     public ResponseCommunityDto getPost(long communityId) {
+        // 단건에 대한 포스트 조회
         CommunityDto communityDto = communityService.getPost(communityId);
+       // 포스트에 해당하는 첨부파일 리스트 조회
         List<CommunityFileDto> communityFileDtos = communityFileService.getFiles(
             communityId);
 
@@ -64,18 +68,21 @@ public class CommunityManagementService {
         communityService.deletePost(communityId);
         communityFileService.deleteAllByCommunityId(communityId);
 
-
     }
 
+    // 단건 업데이트
     @Transactional
     public ResponseCommunityDto updatePost( RequestPostCommunity request) {
 
+        // request에서 필요한 정보만 넘겨서 post업데이트
         CommunityDto communityDto = communityService.updatePost(request.getCommunityId(),
             request.getContinent(),request.getCountry(),request.getRegion(),
             request.getTitle(),request.getContent());
 
+        // post에 관련되어 저장되어있던 파일리스트 전체 삭제
         communityFileService.deleteAllByCommunityId(request.getCommunityId());
 
+        // communityId와 file list 정보를 추출하여 새로 올라온 첨부파일 맵핑
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
 

--- a/travel/src/main/java/com/zerobase/service/CommunityService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityService.java
@@ -1,10 +1,10 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.entity.CommunityEntity;
-import com.zerobase.communities.repository.CommunityRepository;
-import com.zerobase.communities.type.CommunityDto;
-import com.zerobase.communities.type.CustomException;
-import com.zerobase.communities.type.ErrorCode;
+import com.zerobase.repository.CommunityRepository;
+import com.zerobase.entity.CommunityEntity;
+import com.zerobase.model.CommunityDto;
+import com.zerobase.model.type.CustomException;
+import com.zerobase.model.type.ErrorCode;
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
<Controller도입>
API 명세서에 의거하여 Controller method 도입

< Erd 변경 및 entity 구조 변경>
- 기존 erd구조 
1. 결제( 게시글의 하위 테이블)
2. 카카오페이결제이력 (결제의 하위 테이블)

- 변경 erd구조
1. 보증금 (게시글의 하위 테이블) 신규생성
2. 결제이력(보증금의 상위 테이블) 
3. 카카오페이 결제아이디 (결제이력의 하위 테이블)

- 변경의도
1. 결제테이블이 보증금의 아래에 종속하지 않고 보증금이 결제이력에 종속하도록 변경
-> 향후 보증금 결제건 외에 일반 상품구매도 고려하여 변경
2. 결제이력과 카카오페이 결제아이디를 분리하고 카카오페이가 결제이력에 종속되도록 변경
-> 카카오페이 외에 다른 페이로 결제할 것을 고려하여 변경