### PR TITLE
Development/sanghwa pay

### DIFF
--- a/pay/src/main/java/com/zerobase/controller/PayController.java
+++ b/pay/src/main/java/com/zerobase/controller/PayController.java
@@ -1,0 +1,79 @@
+package com.zerobase.controller;
+
+import com.zerobase.model.RequestReadyPayDeposit;
+import com.zerobase.model.type.ResponseDepositPayDto;
+import com.zerobase.service.PayManagmentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/*
+ 페이서비스에 결제 준비를 요청 -> client 결제정보 수신
+ -> client 성공, 실패, 취소에 따라 서로다른 URL 로 연결됨.
+ */
+@RestController
+@RequestMapping(value = "/pay")
+@RequiredArgsConstructor
+@Slf4j
+public class PayController {
+
+    private final PayManagmentService payManagmentService;
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/ready")
+    public ResponseEntity<ResponseDepositPayDto> readyPayDeposit(
+        @RequestBody RequestReadyPayDeposit request) {
+        log.info("request ready pay deposit {}", request.toString());
+        return ResponseEntity.ok(payManagmentService.readyDepositPay(
+            request.getPostId(),
+            request.getParticipationId(), request.getUserId(),
+            request.getPaymentMethod()))
+            ;
+
+    }
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/success")
+    public ResponseEntity<Object> CreatePayDepositSuccess() {
+
+        return null;
+    }
+
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/fail")
+    public ResponseEntity<Object> CreatePayDepositFail() {
+
+        return null;
+    }
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/refund")
+    public ResponseEntity<Object> CreatePayDepositCancel() {
+
+        return null;
+    }
+
+
+    @GetMapping(value = "/deposit")
+    public ResponseEntity<Object> getPayDeposit(
+        @RequestParam String userId, @RequestParam Long postId) {
+
+        return null;
+    }
+
+    @GetMapping
+    public ResponseEntity<Object> getPayHistory() {
+
+        return null;
+    }
+
+
+}

--- a/pay/src/main/java/com/zerobase/entity/DepositEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/DepositEntity.java
@@ -1,0 +1,35 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PaymentMethod;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    // 후속 보충 데이터
+    private String payKey;
+    private Integer amount;
+    private PaymentMethod paymentMethod;
+    // 변경 데이터
+    private DepositStatus depositStatus;
+}

--- a/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
@@ -1,0 +1,34 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.KaKaoPayStatus;
+import com.zerobase.model.type.KaoKaoPayMethod;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoPayPaymentHistoryEntity {
+
+    @Id
+    private Long KakaoPayPaymentHistoryId;
+    private String paymentId;
+    @OneToOne
+    private PaymentHistoryEntity paymentHistoryEntity;
+    private Long userId;
+    private String tid;
+    private String partnerOrderId;
+    private String partnerUserId;
+    private KaKaoPayStatus kaKaoStatus;
+    private KaoKaoPayMethod kaoKaoPayMethod;
+
+}

--- a/pay/src/main/java/com/zerobase/entity/PaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentHistoryEntity.java
@@ -1,0 +1,36 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.PaymentMethod;
+import com.zerobase.model.type.PaymentStatus;
+import com.zerobase.model.type.TransactionType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentHistoryId;
+    private Long userId;
+    private Long amount;
+    private PaymentStatus paymentStatus;
+    private PaymentMethod paymentMethod;
+    // 여기서는 deposit
+    private TransactionType referencialTransactionType;
+    // 여기서는 현재, deposit_id
+    private Long referencialOrderId;
+
+}

--- a/travel/src/main/java/com/zerobase/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/controller/CommunityController.java
@@ -1,9 +1,9 @@
-package com.zerobase.communities.controller;
+package com.zerobase.controller;
 
-import com.zerobase.communities.service.CommunityManagementService;
-import com.zerobase.communities.type.RequestCreateCommunity;
-import com.zerobase.communities.type.RequestPostCommunity;
-import com.zerobase.communities.type.ResponseCommunityDto;
+import com.zerobase.service.CommunityManagementService;
+import com.zerobase.model.RequestCreateCommunity;
+import com.zerobase.model.RequestPostCommunity;
+import com.zerobase.model.ResponseCommunityDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;

--- a/travel/src/main/java/com/zerobase/entity/CommunityEntity.java
+++ b/travel/src/main/java/com/zerobase/entity/CommunityEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.entity;
+package com.zerobase.entity;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;

--- a/travel/src/main/java/com/zerobase/entity/CommunityFileEntity.java
+++ b/travel/src/main/java/com/zerobase/entity/CommunityFileEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.entity;
+package com.zerobase.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/travel/src/main/java/com/zerobase/model/CommunityDto.java
+++ b/travel/src/main/java/com/zerobase/model/CommunityDto.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
-import com.zerobase.communities.entity.CommunityEntity;
+import com.zerobase.entity.CommunityEntity;
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
 import lombok.Builder;

--- a/travel/src/main/java/com/zerobase/model/CommunityFileDto.java
+++ b/travel/src/main/java/com/zerobase/model/CommunityFileDto.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
-import com.zerobase.communities.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityFileEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/travel/src/main/java/com/zerobase/model/RequestCreateCommunity.java
+++ b/travel/src/main/java/com/zerobase/model/RequestCreateCommunity.java
@@ -1,8 +1,7 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -11,11 +10,8 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RequestPostCommunity {
+public class RequestCreateCommunity {
 
-
-    @Min(1)
-    long communityId;
     @NotNull
     Continent continent;
     @NotNull

--- a/travel/src/main/java/com/zerobase/model/RequestPostCommunity.java
+++ b/travel/src/main/java/com/zerobase/model/RequestPostCommunity.java
@@ -1,7 +1,8 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -10,8 +11,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RequestCreateCommunity {
+public class RequestPostCommunity {
 
+
+    @Min(1)
+    long communityId;
     @NotNull
     Continent continent;
     @NotNull

--- a/travel/src/main/java/com/zerobase/model/ResponseCommunityDto.java
+++ b/travel/src/main/java/com/zerobase/model/ResponseCommunityDto.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;

--- a/travel/src/main/java/com/zerobase/model/type/CustomException.java
+++ b/travel/src/main/java/com/zerobase/model/type/CustomException.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model.type;
 
 
 import lombok.AllArgsConstructor;

--- a/travel/src/main/java/com/zerobase/model/type/ErrorCode.java
+++ b/travel/src/main/java/com/zerobase/model/type/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model.type;
 
 public enum ErrorCode {
     COMMUNITY_NON_EXISTENT

--- a/travel/src/main/java/com/zerobase/repository/CommunityFileRepository.java
+++ b/travel/src/main/java/com/zerobase/repository/CommunityFileRepository.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.repository;
+package com.zerobase.repository;
 
-import com.zerobase.communities.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityFileEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/travel/src/main/java/com/zerobase/repository/CommunityRepository.java
+++ b/travel/src/main/java/com/zerobase/repository/CommunityRepository.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.repository;
+package com.zerobase.repository;
 
-import com.zerobase.communities.entity.CommunityEntity;
+import com.zerobase.entity.CommunityEntity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/travel/src/main/java/com/zerobase/service/CommunityFileService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityFileService.java
@@ -1,9 +1,9 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.entity.CommunityEntity;
-import com.zerobase.communities.entity.CommunityFileEntity;
-import com.zerobase.communities.repository.CommunityFileRepository;
-import com.zerobase.communities.type.CommunityFileDto;
+import com.zerobase.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityEntity;
+import com.zerobase.repository.CommunityFileRepository;
+import com.zerobase.model.CommunityFileDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/travel/src/main/java/com/zerobase/service/CommunityManagementService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityManagementService.java
@@ -1,15 +1,13 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.type.CommunityDto;
-import com.zerobase.communities.type.CommunityFileDto;
-import com.zerobase.communities.type.RequestCreateCommunity;
-import com.zerobase.communities.type.RequestPostCommunity;
-import com.zerobase.communities.type.ResponseCommunityDto;
-import java.util.ArrayList;
+import com.zerobase.model.CommunityDto;
+import com.zerobase.model.CommunityFileDto;
+import com.zerobase.model.RequestCreateCommunity;
+import com.zerobase.model.RequestPostCommunity;
+import com.zerobase.model.ResponseCommunityDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,25 +20,29 @@ public class CommunityManagementService {
     private final CommunityFileService communityFileService;
 
 
-    // 포스트 생성
+    // 단건 포스트 생성
     @Transactional
     public ResponseCommunityDto createPost(RequestCreateCommunity request) {
 
+        // request에서 필요한 정보만 넘겨서 post생성
         CommunityDto communityDto = communityService.createPost(
             request.getContinent(),request.getCountry(),request.getRegion(),
             request.getTitle(),request.getContent());
 
+        // 부모 테이블에서 communityId를 추출하고 file list 정보를 추출하여 첨부파일 맵핑
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
 
         return ResponseCommunityDto.fromEntity(communityDto, communityFileDtos);
     }
 
-    //다건 조회
+    //다건 조회 ; 페이징처리
     public Page<ResponseCommunityDto> getPosts(Pageable pageable) {
 
+        // 페이징에 따른 포스트 리스트 조회
         Page<CommunityDto> communityDtos = communityService.getPosts(pageable);
 
+        // 포스트 리스트에 해당하는 첨부파일 리스트를 조회
         Page<ResponseCommunityDto> responseCommunityDtos = communityDtos.map(e
             -> ResponseCommunityDto.fromEntity(e,
             communityFileService.getFiles(e.getCommunityId())));
@@ -50,7 +52,9 @@ public class CommunityManagementService {
 
     // 단건조회
     public ResponseCommunityDto getPost(long communityId) {
+        // 단건에 대한 포스트 조회
         CommunityDto communityDto = communityService.getPost(communityId);
+       // 포스트에 해당하는 첨부파일 리스트 조회
         List<CommunityFileDto> communityFileDtos = communityFileService.getFiles(
             communityId);
 
@@ -64,18 +68,21 @@ public class CommunityManagementService {
         communityService.deletePost(communityId);
         communityFileService.deleteAllByCommunityId(communityId);
 
-
     }
 
+    // 단건 업데이트
     @Transactional
     public ResponseCommunityDto updatePost( RequestPostCommunity request) {
 
+        // request에서 필요한 정보만 넘겨서 post업데이트
         CommunityDto communityDto = communityService.updatePost(request.getCommunityId(),
             request.getContinent(),request.getCountry(),request.getRegion(),
             request.getTitle(),request.getContent());
 
+        // post에 관련되어 저장되어있던 파일리스트 전체 삭제
         communityFileService.deleteAllByCommunityId(request.getCommunityId());
 
+        // communityId와 file list 정보를 추출하여 새로 올라온 첨부파일 맵핑
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
 

--- a/travel/src/main/java/com/zerobase/service/CommunityService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityService.java
@@ -1,10 +1,10 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.entity.CommunityEntity;
-import com.zerobase.communities.repository.CommunityRepository;
-import com.zerobase.communities.type.CommunityDto;
-import com.zerobase.communities.type.CustomException;
-import com.zerobase.communities.type.ErrorCode;
+import com.zerobase.repository.CommunityRepository;
+import com.zerobase.entity.CommunityEntity;
+import com.zerobase.model.CommunityDto;
+import com.zerobase.model.type.CustomException;
+import com.zerobase.model.type.ErrorCode;
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
<Controller도입>
API 명세서에 의거하여 Controller method 도입

< Erd 변경 및 entity 구조 변경>
- 기존 erd구조 
1. 결제( 게시글의 하위 테이블)
2. 카카오페이결제이력 (결제의 하위 테이블)

- 변경 erd구조
1. 보증금 (게시글의 하위 테이블) 신규생성
2. 결제이력(보증금의 상위 테이블) 
3. 카카오페이 결제아이디 (결제이력의 하위 테이블)

- 변경의도
1. 결제테이블이 보증금의 아래에 종속하지 않고 보증금이 결제이력에 종속하도록 변경
-> 향후 보증금 결제건 외에 일반 상품구매도 고려하여 변경
2. 결제이력과 카카오페이 결제아이디를 분리하고 카카오페이가 결제이력에 종속되도록 변경
-> 카카오페이 외에 다른 페이로 결제할 것을 고려하여 변경