### PR TITLE
feat) 결제준비단계 business layer 도입

### DIFF
--- a/pay/build.gradle
+++ b/pay/build.gradle
@@ -18,12 +18,17 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 test {

--- a/pay/src/main/java/com/zerobase/PaySpringMain.java
+++ b/pay/src/main/java/com/zerobase/PaySpringMain.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class Main {
+public class PaySpringMain {
 
     public static void main(String[] args) {
-        SpringApplication.run(Main.class, args);
+        SpringApplication.run(PaySpringMain.class, args);
     }
 }

--- a/pay/src/main/java/com/zerobase/config/Constants.java
+++ b/pay/src/main/java/com/zerobase/config/Constants.java
@@ -1,0 +1,23 @@
+package com.zerobase.config;
+
+public final class Constants {
+
+    // Prevent instantiation
+    private Constants() {}
+
+    // KakaoPay constants
+    public static final String KAKAO_CID = "TC0ONETIME";
+    public static final String KAKAO_APPROVAL_URL = "http://localhost:8080/api/v1/pay/deposit/success";
+    public static final String KAKAO_FAIL_URL = "http://localhost:8080/api/v1/pay/deposit/fail";
+    public static final String KAKAO_CANCEL_URL = "http://localhost:8080/api/v1/pay/deposit/refund";
+
+    // DepositService constants
+    public static final String ITEM_NAME = "여행참여 보증금";
+    public static final long QUANTITY = 1;
+    public static final long DEPOSIT_AMOUNT = 100_000;
+    public static final long TAX_FREE_AMOUNT = DEPOSIT_AMOUNT / 11;
+
+    public static final String SECRET_KEY = "DEVBB2EC55AEA5209485B283C6EAC15502C4B307";
+
+
+}

--- a/pay/src/main/java/com/zerobase/controller/PayController.java
+++ b/pay/src/main/java/com/zerobase/controller/PayController.java
@@ -1,0 +1,79 @@
+package com.zerobase.controller;
+
+import com.zerobase.model.RequestReadyPayDeposit;
+import com.zerobase.model.type.ResponseDepositPayDto;
+import com.zerobase.service.PayManagmentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/*
+ 페이서비스에 결제 준비를 요청 -> client 결제정보 수신
+ -> client 성공, 실패, 취소에 따라 서로다른 URL 로 연결됨.
+ */
+@RestController
+@RequestMapping(value = "/pay")
+@RequiredArgsConstructor
+@Slf4j
+public class PayController {
+
+    private final PayManagmentService payManagmentService;
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/ready")
+    public ResponseEntity<ResponseDepositPayDto> readyPayDeposit(
+        @RequestBody RequestReadyPayDeposit request) {
+        log.info("request ready pay deposit {}", request.toString());
+        return ResponseEntity.ok(payManagmentService.readyDepositPay(
+            request.getPostId(),
+            request.getParticipationId(), request.getUserId(),
+            request.getPaymentMethod()))
+            ;
+
+    }
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/success")
+    public ResponseEntity<Object> CreatePayDepositSuccess() {
+
+        return null;
+    }
+
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/fail")
+    public ResponseEntity<Object> CreatePayDepositFail() {
+
+        return null;
+    }
+
+    // 결제시도후 payDeposit 생성하기
+    @PostMapping(value = "/deposit/refund")
+    public ResponseEntity<Object> CreatePayDepositCancel() {
+
+        return null;
+    }
+
+
+    @GetMapping(value = "/deposit")
+    public ResponseEntity<Object> getPayDeposit(
+        @RequestParam String userId, @RequestParam Long postId) {
+
+        return null;
+    }
+
+    @GetMapping
+    public ResponseEntity<Object> getPayHistory() {
+
+        return null;
+    }
+
+
+}

--- a/pay/src/main/java/com/zerobase/controller/PayController.java
+++ b/pay/src/main/java/com/zerobase/controller/PayController.java
@@ -1,8 +1,8 @@
 package com.zerobase.controller;
 
 import com.zerobase.model.RequestReadyPayDeposit;
-import com.zerobase.model.type.ResponseDepositPayDto;
-import com.zerobase.service.PayManagmentService;
+import com.zerobase.model.ResponseDepositPayDto;
+import com.zerobase.service.PayManagementService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,22 +19,22 @@ import org.springframework.web.bind.annotation.RestController;
  -> client 성공, 실패, 취소에 따라 서로다른 URL 로 연결됨.
  */
 @RestController
-@RequestMapping(value = "/pay")
+@RequestMapping(value = "/api/v1/pay")
 @RequiredArgsConstructor
 @Slf4j
 public class PayController {
 
-    private final PayManagmentService payManagmentService;
+    private final PayManagementService payManagmentService;
 
     // 결제시도후 payDeposit 생성하기
     @PostMapping(value = "/deposit/ready")
     public ResponseEntity<ResponseDepositPayDto> readyPayDeposit(
         @RequestBody RequestReadyPayDeposit request) {
         log.info("request ready pay deposit {}", request.toString());
-        return ResponseEntity.ok(payManagmentService.readyDepositPay(
+        return ResponseEntity.ok(payManagmentService.createDepositOrderAndInitiatePay(
             request.getPostId(),
             request.getParticipationId(), request.getUserId(),
-            request.getPaymentMethod()))
+            request.getPgMethod()))
             ;
 
     }

--- a/pay/src/main/java/com/zerobase/entity/DepositEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/DepositEntity.java
@@ -1,0 +1,35 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PaymentMethod;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    // 후속 보충 데이터
+    private String payKey;
+    private Integer amount;
+    private PaymentMethod paymentMethod;
+    // 변경 데이터
+    private DepositStatus depositStatus;
+}

--- a/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
@@ -1,7 +1,7 @@
 package com.zerobase.entity;
 
 import com.zerobase.model.type.KaKaoPayStatus;
-import com.zerobase.model.type.KaoKaoPayMethod;
+import com.zerobase.model.type.PayMethod;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
@@ -21,14 +21,12 @@ public class KakaoPayPaymentHistoryEntity {
 
     @Id
     private Long KakaoPayPaymentHistoryId;
-    private String paymentId;
-    @OneToOne
-    private PaymentHistoryEntity paymentHistoryEntity;
+    private Long paymentId;
     private Long userId;
     private String tid;
     private String partnerOrderId;
     private String partnerUserId;
     private KaKaoPayStatus kaKaoStatus;
-    private KaoKaoPayMethod kaoKaoPayMethod;
-
+    private PayMethod payMethod;
+    private Long amount;
 }

--- a/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
@@ -1,0 +1,34 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.KaKaoPayStatus;
+import com.zerobase.model.type.KaoKaoPayMethod;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoPayPaymentHistoryEntity {
+
+    @Id
+    private Long KakaoPayPaymentHistoryId;
+    private String paymentId;
+    @OneToOne
+    private PaymentHistoryEntity paymentHistoryEntity;
+    private Long userId;
+    private String tid;
+    private String partnerOrderId;
+    private String partnerUserId;
+    private KaKaoPayStatus kaKaoStatus;
+    private KaoKaoPayMethod kaoKaoPayMethod;
+
+}

--- a/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
@@ -32,6 +32,6 @@ public class PaymentEntity {
     // 여기서는 deposit
     private OrderType referencialOrderType;
     // 여기서는 현재, deposit_id
-    private Long referencialOrderId;
+    private Long referentialOrderId;
 
 }

--- a/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
@@ -1,6 +1,8 @@
 package com.zerobase.entity;
 
-import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.OrderType;
+import com.zerobase.model.type.PGMethod;
+import com.zerobase.model.type.PaymentStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,14 +19,19 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DepositEntity {
+public class PaymentEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long depositId;
-    private Long postId;
-    private Long participationId;
+    private Long paymentId;
+    private String paykey;
     private String userId;
+    private Long amount;
+    private PaymentStatus paymentStatus;
+    private PGMethod pgMethod;
+    // 여기서는 deposit
+    private OrderType referencialOrderType;
+    // 여기서는 현재, deposit_id
+    private Long referencialOrderId;
 
-    private DepositStatus depositStatus;
 }

--- a/pay/src/main/java/com/zerobase/entity/PaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentHistoryEntity.java
@@ -1,0 +1,36 @@
+package com.zerobase.entity;
+
+import com.zerobase.model.type.PaymentMethod;
+import com.zerobase.model.type.PaymentStatus;
+import com.zerobase.model.type.TransactionType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentHistoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long paymentHistoryId;
+    private Long userId;
+    private Long amount;
+    private PaymentStatus paymentStatus;
+    private PaymentMethod paymentMethod;
+    // 여기서는 deposit
+    private TransactionType referencialTransactionType;
+    // 여기서는 현재, deposit_id
+    private Long referencialOrderId;
+
+}

--- a/pay/src/main/java/com/zerobase/model/PaymentDto.java
+++ b/pay/src/main/java/com/zerobase/model/PaymentDto.java
@@ -1,0 +1,38 @@
+package com.zerobase.model;
+
+import com.zerobase.entity.PaymentEntity;
+import com.zerobase.model.type.OrderType;
+import com.zerobase.model.type.PGMethod;
+import com.zerobase.model.type.PaymentStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Builder
+@Getter
+@Setter
+public class PaymentDto {
+    private Long paymentId;
+    private OrderType referencialOrderType;
+    private Long referentialOrderId;
+    private String userId;
+    private String payKey;
+    private Long amount;
+    private PaymentStatus paymentStatus;
+    private PGMethod pgMethod;
+
+    public static PaymentDto fromEntity(PaymentEntity paymentEntity) {
+        return PaymentDto.builder()
+            .paymentId(paymentEntity.getPaymentId())
+            .referencialOrderType(paymentEntity.getReferencialOrderType())
+            .referentialOrderId(paymentEntity.getReferencialOrderId())
+            .userId(paymentEntity.getUserId())
+            .amount(paymentEntity.getAmount())
+            .pgMethod(paymentEntity.getPgMethod())
+            .paymentStatus(paymentEntity.getPaymentStatus())
+            .build();
+
+
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/type/DepositStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/DepositStatus.java
@@ -1,0 +1,8 @@
+package com.zerobase.model.type;
+
+public enum DepositStatus {
+    PAID,
+    REFUNDED,
+    BEFORE_PAYMENT,
+    FAILED
+}

--- a/pay/src/main/java/com/zerobase/model/type/KaKaoPayStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/KaKaoPayStatus.java
@@ -1,0 +1,5 @@
+package com.zerobase.model.type;
+
+public enum KaKaoPayStatus {
+    SUCCESS, FAILED,REFUND;
+}

--- a/pay/src/main/java/com/zerobase/model/type/OrderType.java
+++ b/pay/src/main/java/com/zerobase/model/type/OrderType.java
@@ -1,0 +1,5 @@
+package com.zerobase.model.type;
+
+public enum OrderType {
+    DEPOSIT
+}

--- a/pay/src/main/java/com/zerobase/model/type/PGMethod.java
+++ b/pay/src/main/java/com/zerobase/model/type/PGMethod.java
@@ -1,0 +1,9 @@
+package com.zerobase.model.type;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum PGMethod {
+    @JsonProperty("KAKAOPAY")
+    KAKAOPAY;
+
+}

--- a/pay/src/main/java/com/zerobase/model/type/PayMethod.java
+++ b/pay/src/main/java/com/zerobase/model/type/PayMethod.java
@@ -1,0 +1,5 @@
+package com.zerobase.model.type;
+
+public enum PayMethod {
+    MONEY,CARD;
+}

--- a/pay/src/main/java/com/zerobase/model/type/PaymentStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/PaymentStatus.java
@@ -1,0 +1,11 @@
+package com.zerobase.model.type;
+
+public enum PaymentStatus {
+    PAY_IN_PROGRESS,
+    PAY_COMPLETED,
+    PAY_FAILED,
+    PAY_REFUNDED
+}
+
+
+

--- a/pay/src/main/java/com/zerobase/repository/DepositRepository.java
+++ b/pay/src/main/java/com/zerobase/repository/DepositRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.repository;
+
+import com.zerobase.entity.DepositEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DepositRepository extends JpaRepository<DepositEntity,Long> {
+
+    Optional<DepositEntity> findByParticipationId(Long participationId);
+}

--- a/pay/src/main/java/com/zerobase/repository/KakaoPayHistoryRepository.java
+++ b/pay/src/main/java/com/zerobase/repository/KakaoPayHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.repository;
+
+import com.zerobase.entity.KakaoPayPaymentHistoryEntity;
+import com.zerobase.entity.PaymentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KakaoPayHistoryRepository extends JpaRepository<KakaoPayPaymentHistoryEntity,Long> {
+
+}

--- a/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
+++ b/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
@@ -1,0 +1,15 @@
+package com.zerobase.repository;
+
+import com.zerobase.entity.PaymentEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<PaymentEntity,Long> {
+
+    Optional<PaymentEntity> findByPaykey(String tid);
+
+    Optional<PaymentEntity> findByReferencialOrderId(Long referentialOrderId);
+
+}

--- a/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
+++ b/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
@@ -10,6 +10,7 @@ public interface PaymentRepository extends JpaRepository<PaymentEntity,Long> {
 
     Optional<PaymentEntity> findByPaykey(String tid);
 
-    Optional<PaymentEntity> findByReferencialOrderId(Long referentialOrderId);
+    Optional<PaymentEntity> findByReferentialOrderId(Long referentialOrderId);
+
 
 }

--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -1,0 +1,68 @@
+package com.zerobase.service;
+
+import com.zerobase.entity.DepositEntity;
+import com.zerobase.model.DepositDto;
+import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.repository.DepositRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class DepositService {
+
+    private final DepositRepository depositRepository;
+
+
+
+
+
+    // depositId를 생성하기 위해서
+    public DepositDto createDepositOrder(Long postId, Long participationId,
+        String userId) {
+        log.info("DepositRepository initial save start");
+
+        DepositEntity depositEntity = DepositEntity.builder()
+            .postId(postId)
+            .participationId(participationId)
+            .userId(userId)
+            .depositStatus(DepositStatus.BEFORE_PAYMENT)
+            .build();
+
+        return DepositDto.fromEntity(depositRepository.save(depositEntity));
+    }
+
+
+
+/*
+    public void changeStatusToCompleteByOrderId(Long referentialOrderId) {
+        DepositEntity depositEntity = depositRepository.findById(
+            referentialOrderId).orElseThrow(
+            () -> new CustomException());
+
+        depositEntity.setDepositStatus(DepositStatus.PAID);
+    }
+
+    public void changeStatusToFailByOrderId(Long referentialOrderId) {
+        DepositEntity depositEntity = depositRepository.findById(
+            referentialOrderId).orElseThrow(
+            () -> new CustomException());
+
+        depositEntity.setDepositStatus(DepositStatus.FAILED);
+    }
+
+    public DepositDto changeStatusToRefundedByParticipationId(Long participationId) {
+
+        DepositEntity depositEntity = depositRepository.findByParticipationId(
+            participationId).orElseThrow(() -> new CustomException());
+
+        depositEntity.setDepositStatus(DepositStatus.REFUNDED);
+    return null;
+    }
+
+ */
+}

--- a/pay/src/main/java/com/zerobase/service/KakaopayApiService.java
+++ b/pay/src/main/java/com/zerobase/service/KakaopayApiService.java
@@ -1,0 +1,137 @@
+package com.zerobase.service;
+
+import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
+import static com.zerobase.config.Constants.ITEM_NAME;
+import static com.zerobase.config.Constants.KAKAO_APPROVAL_URL;
+import static com.zerobase.config.Constants.KAKAO_CANCEL_URL;
+import static com.zerobase.config.Constants.KAKAO_CID;
+import static com.zerobase.config.Constants.KAKAO_FAIL_URL;
+import static com.zerobase.config.Constants.QUANTITY;
+import static com.zerobase.config.Constants.SECRET_KEY;
+import static com.zerobase.config.Constants.TAX_FREE_AMOUNT;
+
+import com.zerobase.model.ResponseApi;
+import com.zerobase.model.ResponseApi.PayRefundApiDto;
+import com.zerobase.model.RequestApi;
+import com.zerobase.model.RequestApi.ConfirmDto;
+import com.zerobase.model.RequestApi.RefundDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class KakaopayApiService implements ApiService {
+
+
+
+
+
+
+    @Override
+    public ResponseApi.PayReadyApiDto sendPayReadySign( Long orderId, String userId) {
+        log.info("KakaopayApiService sendPayReadySign");
+        // webclient url, header입력
+
+        WebClient webclient = WebClient.builder()
+            .baseUrl("https://open-api.kakaopay.com")
+            .defaultHeader("Content-Type", "application/json")
+            .defaultHeader("Authorization", "SECRET_KEY "+ SECRET_KEY)
+            .build();
+
+        RequestApi.ReadyDto readyApiDto = RequestApi.ReadyDto.builder()
+            .cid(KAKAO_CID)
+            .partnerOrderId(String.valueOf(orderId))
+            .partnerUserId(userId)
+            .itemName(ITEM_NAME)
+            .quantity(String.valueOf(QUANTITY))
+            .totalAmount(String.valueOf(DEPOSIT_AMOUNT))
+            .taxFreeAmount(String.valueOf(TAX_FREE_AMOUNT))
+            .approvalUrl(KAKAO_APPROVAL_URL)
+            .cancelUrl(KAKAO_CANCEL_URL)
+            .failUrl(KAKAO_FAIL_URL)
+            .build();
+        //
+        ResponseApi.PayReadyApiDto payReadyApiDto = webclient.post()
+            .uri("/online/v1/payment/ready")
+            .bodyValue(
+                readyApiDto
+            )
+            .retrieve()
+            .bodyToMono(ResponseApi.PayReadyApiDto.class)
+            .block();
+
+        return payReadyApiDto;
+    }
+
+    /*
+
+    public ResponseApi.PayConfirmDto sendPayConfirmSign(
+        String tid, Long orderId, String userId, String pgToken) {
+        log.info("KakaopayApiService payconfirmsign");
+        // webclient url, header입력
+
+        WebClient webclient = WebClient.builder()
+            .baseUrl("https://open-api.kakaopay.com")
+            .defaultHeader("Content-Type", "application/json")
+            .defaultHeader("Authorization", "SECRET_KEY " + SECRET_KEY)
+            .build();
+
+        ConfirmDto confirmDto = ConfirmDto.builder()
+            .cid(KAKAO_CID)
+            .tid(tid)
+            .partnerOrderId(String.valueOf(orderId))
+            .partnerUserId(userId)
+            .pgToken(pgToken)
+            .build();
+        //
+        ResponseApi.PayConfirmDto payConfirmDto = webclient.post()
+            .uri("/online/v1/payment/approve")
+            .bodyValue(
+                confirmDto
+            )
+            .retrieve()
+            .bodyToMono(ResponseApi.PayConfirmDto.class)
+            .block();
+
+        return payConfirmDto;
+    }
+
+    public PayRefundApiDto sendPayRefundSign(
+         String tid, Long cancelAmount, Long cancel_tax_free_amount ) {
+        log.info("KakaopayApiService payRefundSign");
+        // webclient url, header입력
+
+        WebClient webclient = WebClient.builder()
+            .baseUrl("https://open-api.kakaopay.com")
+            .defaultHeader("Content-Type", "application/json")
+            .defaultHeader("Authorization", "SECRET_KEY " + SECRET_KEY)
+            .build();
+
+        RequestApi.RefundDto refundDto = RefundDto.builder()
+            .cid(KAKAO_CID)
+            .tid(tid)
+            .cancelAmount(String.valueOf(cancelAmount))
+            .cancelTaxFreeAmount(String.valueOf(cancel_tax_free_amount))
+            .build();
+        //
+        PayRefundApiDto payRefundApiDto = webclient.post()
+            .uri("/online/v1/payment/cancel")
+            .bodyValue(
+                refundDto
+            )
+            .retrieve()
+            .bodyToMono(PayRefundApiDto.class)
+            .block();
+
+        return payRefundApiDto;
+    }
+
+
+     */
+}
+
+
+

--- a/pay/src/main/java/com/zerobase/service/PayManagementService.java
+++ b/pay/src/main/java/com/zerobase/service/PayManagementService.java
@@ -1,0 +1,135 @@
+package com.zerobase.service;
+
+import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
+import static com.zerobase.config.Constants.TAX_FREE_AMOUNT;
+
+import com.zerobase.model.DepositDto;
+import com.zerobase.model.PayReadyApiDto;
+import com.zerobase.model.ResponseApi;
+import com.zerobase.model.ResponseApi.PayRefundApiDto;
+import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.type.PGMethod;
+import com.zerobase.model.type.PaymentDto;
+import com.zerobase.model.ResponseDepositPayDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PayManagementService {
+
+    private final DepositService depositService;
+    private final KakaopayApiService kakaopayApiService;
+    private final PaymentService paymentService;
+
+    /*
+    1. travel 모듈에서 여행참가(participationId) 데이터가 생성될 때 pay module로 참가 데이터를 발송함.
+    2. 참가 데이터를 받은 결제모듈은 상품주문(depositId) 데이터를 생성하고 PG사 API를 통해 결제진행 요청을 받은 후
+    거래번호(tid)와 결제인증 url을 응답받음.
+    3. 결제 Id역시 생성함
+    4. 이중 url은 client로 발송하며 tid는 내부저장함
+     */
+    @Transactional
+    public ResponseDepositPayDto createDepositOrderAndInitiatePay(
+        Long postId, Long participationId, String userId, PGMethod pgMethod) {
+        log.info("readyDepositPay");
+
+        // deposit 생성
+        DepositDto depositDto = depositService.createDepositOrder(postId,
+            participationId, userId);
+
+        // pg 사와 통신을 통해 tid 추출
+        ResponseApi.PayReadyApiDto payReadyApiDto = kakaopayApiService.sendPayReadySign(
+            participationId, userId);
+
+        // tid를 기반으로 결제데이터 생성 & 카카오페이 결제 이력 저장
+        PaymentDto payment = paymentService.createPayment(
+            depositDto.getDepositId(), userId, payReadyApiDto.getTid(),
+            pgMethod);
+
+        return ResponseDepositPayDto.builder()
+            .depositId(depositDto.getDepositId())
+            .postId(depositDto.getPostId())
+            .participationId(depositDto.getParticipationId())
+            .userId(depositDto.getUserId())
+            .depositStatus(depositDto.getDepositStatus())
+            .amount(payment.getAmount())
+            .next_redirect_pc_url(payReadyApiDto.getNext_redirect_pc_url())
+            .build();
+    }
+
+    /* 기능 기획에 대한 상세 회의 진행후 코드 완성진행
+
+    /*
+    1. 사용자는 pg사 로부터 결제 인증을 성공하면 성공 url로 연결되어 서버에 tid와 pg token을 전송함
+    2. 페이 히스토리 entity에 이력을 저장하고 deposit과 payment entity의 상태를 변경함
+
+
+    @Transactional
+    public void successDepositPay(
+        String userId, String tid, String pgToken) {
+        log.info("success customer DepositPay");
+
+        PaymentDto paymentDto = paymentService.ChangeStatusToCompleteByTid(tid);
+
+        ResponseApi.PayConfirmDto payConfirmDto;
+        try {
+            payConfirmDto = kakaopayApiService.sendPayConfirmSign(
+                tid, paymentDto.getReferentialOrderId(), userId, pgToken);
+        } catch (Exception e) {
+            throw new CustomException();
+        }
+
+        depositService.changeStatusToCompleteByOrderId(
+            paymentDto.getReferentialOrderId());
+
+    }
+
+    1. 사용자는 pg사 로부터 결제 인증을 성공하면 성공 url로 연결되어 서버에 tid와 pg token을 전송함
+    2. 페이 히스토리 entity에 이력을 저장하고 deposit과 payment entity의 상태를 변경함
+
+
+    @Transactional
+    public void failedDepositPay(String tid) {
+        log.info("fail customer DepositPay");
+
+        PaymentDto paymentDto = paymentService.ChangeStatusToFailByTid(tid);
+        depositService.changeStatusToFailByOrderId(
+            paymentDto.getReferentialOrderId());
+    }
+
+
+
+        tid 정보를 통해서 server 측에서 pg사에 API를 통해 취소요청이 가능함.
+        client 측에서는 participation을 기준으로 취소요청을 할 것으로 생각됨.
+
+
+
+    @Transactional
+    public void refundDepositPay(
+        Long participationId) {
+        log.info("refund customer DepositPay");
+
+        DepositDto depositDto = depositService.
+            changeStatusToRefundedByParticipationId(participationId);
+
+        PaymentDto paymentDto = paymentService.
+            ChangeStatusToRefundedByOrderId(depositDto.getDepositId());
+
+        PayRefundApiDto payRefundApiDto;
+        try {
+            payRefundApiDto = kakaopayApiService.sendPayRefundSign(
+                paymentDto.getPayKey(), DEPOSIT_AMOUNT, TAX_FREE_AMOUNT);
+        } catch (Exception e) {
+            throw new CustomException();
+        }
+
+
+    }
+    */
+
+
+}

--- a/pay/src/main/java/com/zerobase/service/PaymentService.java
+++ b/pay/src/main/java/com/zerobase/service/PaymentService.java
@@ -1,0 +1,72 @@
+package com.zerobase.service;
+
+import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
+
+import com.zerobase.entity.PaymentEntity;
+import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.type.OrderType;
+import com.zerobase.model.type.PGMethod;
+import com.zerobase.model.type.PaymentDto;
+import com.zerobase.model.type.PaymentStatus;
+import com.zerobase.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository ;
+
+
+    public PaymentDto createPayment(Long depositId, String userId, String payKey,
+        PGMethod pgMethod) {
+
+        PaymentEntity paymentEntity = paymentRepository.save(
+            PaymentEntity.builder()
+                .referencialOrderType(OrderType.DEPOSIT)
+                .referentialOrderId(depositId)
+                .userId(userId)
+                .paykey(payKey)
+                .amount(DEPOSIT_AMOUNT)
+                .paymentStatus(PaymentStatus.PAY_IN_PROGRESS)
+                .pgMethod(pgMethod)
+                .build());
+
+        return PaymentDto.fromEntity(paymentEntity);
+
+    }
+
+    public PaymentDto ChangeStatusToCompleteByTid(String payKey) {
+
+        PaymentEntity paymentEntity = paymentRepository.findByPaykey(payKey)
+            .orElseThrow(() -> new CustomException());
+
+        paymentEntity.setPaymentStatus(PaymentStatus.PAY_COMPLETED);
+        paymentRepository.save(paymentEntity);
+
+        return PaymentDto.fromEntity(paymentEntity);
+    }
+
+    public PaymentDto ChangeStatusToFailByTid(String payKey) {
+
+        PaymentEntity paymentEntity = paymentRepository.findByPaykey(payKey)
+            .orElseThrow(() -> new CustomException());
+
+        paymentEntity.setPaymentStatus(PaymentStatus.PAY_FAILED);
+        paymentRepository.save(paymentEntity);
+
+        return PaymentDto.fromEntity(paymentEntity);
+    }
+
+    public PaymentDto ChangeStatusToRefundedByOrderId(Long referencialOrderId) {
+        PaymentEntity paymentEntity = paymentRepository
+            .findByReferentialOrderId(referencialOrderId)
+            .orElseThrow(() -> new CustomException());
+
+        paymentEntity.setPaymentStatus(PaymentStatus.PAY_REFUNDED);
+        paymentRepository.save(paymentEntity);
+
+        return PaymentDto.fromEntity(paymentEntity);
+    }
+}

--- a/travel/src/main/java/com/zerobase/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/controller/CommunityController.java
@@ -1,9 +1,9 @@
-package com.zerobase.communities.controller;
+package com.zerobase.controller;
 
-import com.zerobase.communities.service.CommunityManagementService;
-import com.zerobase.communities.type.RequestCreateCommunity;
-import com.zerobase.communities.type.RequestPostCommunity;
-import com.zerobase.communities.type.ResponseCommunityDto;
+import com.zerobase.service.CommunityManagementService;
+import com.zerobase.model.RequestCreateCommunity;
+import com.zerobase.model.RequestPostCommunity;
+import com.zerobase.model.ResponseCommunityDto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;

--- a/travel/src/main/java/com/zerobase/entity/CommunityEntity.java
+++ b/travel/src/main/java/com/zerobase/entity/CommunityEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.entity;
+package com.zerobase.entity;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;

--- a/travel/src/main/java/com/zerobase/entity/CommunityFileEntity.java
+++ b/travel/src/main/java/com/zerobase/entity/CommunityFileEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.entity;
+package com.zerobase.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/travel/src/main/java/com/zerobase/model/CommunityDto.java
+++ b/travel/src/main/java/com/zerobase/model/CommunityDto.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
-import com.zerobase.communities.entity.CommunityEntity;
+import com.zerobase.entity.CommunityEntity;
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
 import lombok.Builder;

--- a/travel/src/main/java/com/zerobase/model/CommunityFileDto.java
+++ b/travel/src/main/java/com/zerobase/model/CommunityFileDto.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
-import com.zerobase.communities.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityFileEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/travel/src/main/java/com/zerobase/model/RequestCreateCommunity.java
+++ b/travel/src/main/java/com/zerobase/model/RequestCreateCommunity.java
@@ -1,8 +1,7 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -11,11 +10,8 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RequestPostCommunity {
+public class RequestCreateCommunity {
 
-
-    @Min(1)
-    long communityId;
     @NotNull
     Continent continent;
     @NotNull

--- a/travel/src/main/java/com/zerobase/model/RequestPostCommunity.java
+++ b/travel/src/main/java/com/zerobase/model/RequestPostCommunity.java
@@ -1,7 +1,8 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -10,8 +11,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RequestCreateCommunity {
+public class RequestPostCommunity {
 
+
+    @Min(1)
+    long communityId;
     @NotNull
     Continent continent;
     @NotNull

--- a/travel/src/main/java/com/zerobase/model/ResponseCommunityDto.java
+++ b/travel/src/main/java/com/zerobase/model/ResponseCommunityDto.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model;
 
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;

--- a/travel/src/main/java/com/zerobase/model/type/CustomException.java
+++ b/travel/src/main/java/com/zerobase/model/type/CustomException.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model.type;
 
 
 import lombok.AllArgsConstructor;

--- a/travel/src/main/java/com/zerobase/model/type/ErrorCode.java
+++ b/travel/src/main/java/com/zerobase/model/type/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.zerobase.communities.type;
+package com.zerobase.model.type;
 
 public enum ErrorCode {
     COMMUNITY_NON_EXISTENT

--- a/travel/src/main/java/com/zerobase/repository/CommunityFileRepository.java
+++ b/travel/src/main/java/com/zerobase/repository/CommunityFileRepository.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.repository;
+package com.zerobase.repository;
 
-import com.zerobase.communities.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityFileEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/travel/src/main/java/com/zerobase/repository/CommunityRepository.java
+++ b/travel/src/main/java/com/zerobase/repository/CommunityRepository.java
@@ -1,6 +1,6 @@
-package com.zerobase.communities.repository;
+package com.zerobase.repository;
 
-import com.zerobase.communities.entity.CommunityEntity;
+import com.zerobase.entity.CommunityEntity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/travel/src/main/java/com/zerobase/service/CommunityFileService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityFileService.java
@@ -1,9 +1,9 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.entity.CommunityEntity;
-import com.zerobase.communities.entity.CommunityFileEntity;
-import com.zerobase.communities.repository.CommunityFileRepository;
-import com.zerobase.communities.type.CommunityFileDto;
+import com.zerobase.entity.CommunityFileEntity;
+import com.zerobase.entity.CommunityEntity;
+import com.zerobase.repository.CommunityFileRepository;
+import com.zerobase.model.CommunityFileDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/travel/src/main/java/com/zerobase/service/CommunityManagementService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityManagementService.java
@@ -1,15 +1,13 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.type.CommunityDto;
-import com.zerobase.communities.type.CommunityFileDto;
-import com.zerobase.communities.type.RequestCreateCommunity;
-import com.zerobase.communities.type.RequestPostCommunity;
-import com.zerobase.communities.type.ResponseCommunityDto;
-import java.util.ArrayList;
+import com.zerobase.model.CommunityDto;
+import com.zerobase.model.CommunityFileDto;
+import com.zerobase.model.RequestCreateCommunity;
+import com.zerobase.model.RequestPostCommunity;
+import com.zerobase.model.ResponseCommunityDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,25 +20,29 @@ public class CommunityManagementService {
     private final CommunityFileService communityFileService;
 
 
-    // 포스트 생성
+    // 단건 포스트 생성
     @Transactional
     public ResponseCommunityDto createPost(RequestCreateCommunity request) {
 
+        // request에서 필요한 정보만 넘겨서 post생성
         CommunityDto communityDto = communityService.createPost(
             request.getContinent(),request.getCountry(),request.getRegion(),
             request.getTitle(),request.getContent());
 
+        // 부모 테이블에서 communityId를 추출하고 file list 정보를 추출하여 첨부파일 맵핑
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
 
         return ResponseCommunityDto.fromEntity(communityDto, communityFileDtos);
     }
 
-    //다건 조회
+    //다건 조회 ; 페이징처리
     public Page<ResponseCommunityDto> getPosts(Pageable pageable) {
 
+        // 페이징에 따른 포스트 리스트 조회
         Page<CommunityDto> communityDtos = communityService.getPosts(pageable);
 
+        // 포스트 리스트에 해당하는 첨부파일 리스트를 조회
         Page<ResponseCommunityDto> responseCommunityDtos = communityDtos.map(e
             -> ResponseCommunityDto.fromEntity(e,
             communityFileService.getFiles(e.getCommunityId())));
@@ -50,7 +52,9 @@ public class CommunityManagementService {
 
     // 단건조회
     public ResponseCommunityDto getPost(long communityId) {
+        // 단건에 대한 포스트 조회
         CommunityDto communityDto = communityService.getPost(communityId);
+       // 포스트에 해당하는 첨부파일 리스트 조회
         List<CommunityFileDto> communityFileDtos = communityFileService.getFiles(
             communityId);
 
@@ -64,18 +68,21 @@ public class CommunityManagementService {
         communityService.deletePost(communityId);
         communityFileService.deleteAllByCommunityId(communityId);
 
-
     }
 
+    // 단건 업데이트
     @Transactional
     public ResponseCommunityDto updatePost( RequestPostCommunity request) {
 
+        // request에서 필요한 정보만 넘겨서 post업데이트
         CommunityDto communityDto = communityService.updatePost(request.getCommunityId(),
             request.getContinent(),request.getCountry(),request.getRegion(),
             request.getTitle(),request.getContent());
 
+        // post에 관련되어 저장되어있던 파일리스트 전체 삭제
         communityFileService.deleteAllByCommunityId(request.getCommunityId());
 
+        // communityId와 file list 정보를 추출하여 새로 올라온 첨부파일 맵핑
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
 

--- a/travel/src/main/java/com/zerobase/service/CommunityService.java
+++ b/travel/src/main/java/com/zerobase/service/CommunityService.java
@@ -1,10 +1,10 @@
-package com.zerobase.communities.service;
+package com.zerobase.service;
 
-import com.zerobase.communities.entity.CommunityEntity;
-import com.zerobase.communities.repository.CommunityRepository;
-import com.zerobase.communities.type.CommunityDto;
-import com.zerobase.communities.type.CustomException;
-import com.zerobase.communities.type.ErrorCode;
+import com.zerobase.repository.CommunityRepository;
+import com.zerobase.entity.CommunityEntity;
+import com.zerobase.model.CommunityDto;
+import com.zerobase.model.type.CustomException;
+import com.zerobase.model.type.ErrorCode;
 import com.zerobase.typeCommon.Continent;
 import com.zerobase.typeCommon.Country;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION

## 🔍 PR을 통해 해결하려는 문제

여행참가를 위하여 PaymentMangementService를 facade로 하는 비즈니스로직 서비스 구현

## 🔑 PR에서 핵심적으로 변경된 사항

**AS-IS**
비즈니스 로직 신규생성

**TO-BE**
비즈니스로직 및 코드내용 as below

1. 보증금 서비스 내에서 보증금 entity 생성하여 주문 생성, 상태(결제 진행중)
2. client의 결제수단(현재 카카오페이 유일) 선택과 주문데이터(보증금 entity)를 저장하는 결제 데이터 생성
3.  카카오 api 호출을 통한 지불준비 
4.  카카오톡 api 호출결과를  결제히스토리로 저장

* 결제준비 단계 이후의 method는 기획내용 추가 구체화 및 합의가 필요하여 상세개발 보류

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
1. 보증금 가격과 수량 등 보증금관련 상수데이터 , 카카오페이 mock test 진행을 위한 데이터 등 필요 상수 도입

<!-- 없으면 없음으로 표기  -->

### 테스트
API 테스트 진행 완료후 테스트 코드 작성진행

- [ ] 테스트 코드
<!-- 테스트 방식 상세기술 권장 --> 
    
- [ ] API 테스트 
<!-- 테스트 방식 상세기술 권장 --> 