### PR TITLE
Feat/pay controller 및 계층별 dto 생성

### DIFF
--- a/pay/src/main/java/com/zerobase/model/DepositDto.java
+++ b/pay/src/main/java/com/zerobase/model/DepositDto.java
@@ -1,0 +1,34 @@
+package com.zerobase.model;
+
+import com.zerobase.entity.DepositEntity;
+import com.zerobase.model.type.DepositStatus;
+import com.zerobase.model.type.PGMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositDto {
+    private Long depositId;
+    private Long postId;
+    private Long participationId;
+    private String userId;
+    private DepositStatus depositStatus;
+
+    public static DepositDto fromEntity(DepositEntity entity) {
+        return DepositDto.builder()
+            .depositId(entity.getDepositId())
+            .postId(entity.getPostId())
+            .participationId(entity.getParticipationId())
+            .userId(entity.getUserId())
+
+            .depositStatus(entity.getDepositStatus())
+            .build();
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/PayReadyApiDto.java
+++ b/pay/src/main/java/com/zerobase/model/PayReadyApiDto.java
@@ -1,0 +1,17 @@
+package com.zerobase.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PayReadyApiDto {
+    private String tid;
+    private String next_redirect_pc_url;
+}

--- a/pay/src/main/java/com/zerobase/model/RequestApi.java
+++ b/pay/src/main/java/com/zerobase/model/RequestApi.java
@@ -1,0 +1,100 @@
+package com.zerobase.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class RequestApi {
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ConfirmDto {
+
+        private String cid;
+
+        private String tid;
+
+        @JsonProperty("total_amount")
+        private String totalAmount;
+
+        @JsonProperty("tax_free_amount")
+        private String taxFreeAmount;
+
+
+        @JsonProperty("partner_order_id")
+        private String partnerOrderId;
+
+        @JsonProperty("partner_user_id")
+        private String partnerUserId;
+
+        @JsonProperty("pg_token")
+        private String pgToken;
+
+
+
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReadyDto {
+        private String cid;
+
+        @JsonProperty("partner_order_id")
+        private String partnerOrderId;
+
+        @JsonProperty("partner_user_id")
+        private String partnerUserId;
+
+        @JsonProperty("item_name")
+        private String itemName;
+
+        @JsonProperty("quantity")
+        private String quantity;
+
+        @JsonProperty("total_amount")
+        private String totalAmount;
+
+        @JsonProperty("tax_free_amount")
+        private String taxFreeAmount;
+
+        @JsonProperty("approval_url")
+        private  String approvalUrl;
+
+        @JsonProperty("cancel_url")
+        private  String cancelUrl;
+
+        @JsonProperty("fail_url")
+        private  String failUrl;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RefundDto {
+
+        private String cid;
+
+        private String tid;
+
+        @JsonProperty("cancel_amount")
+        private String cancelAmount;
+
+        @JsonProperty("cancel_tax_free_amount")
+        private String cancelTaxFreeAmount;
+
+
+
+
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/RequestConfirmPayDeposit.java
+++ b/pay/src/main/java/com/zerobase/model/RequestConfirmPayDeposit.java
@@ -1,0 +1,18 @@
+package com.zerobase.model;
+
+import com.zerobase.model.type.PGMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestConfirmPayDeposit {
+    Long depositId;
+    PGMethod pgMethod;
+}

--- a/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
+++ b/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
@@ -1,0 +1,20 @@
+package com.zerobase.model;
+
+import com.zerobase.model.type.PGMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestReadyPayDeposit {
+    Long postId;
+    Long participationId;
+    String userId;
+    PGMethod pgMethod;
+}

--- a/pay/src/main/java/com/zerobase/model/ResponseApi.java
+++ b/pay/src/main/java/com/zerobase/model/ResponseApi.java
@@ -1,0 +1,49 @@
+package com.zerobase.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zerobase.model.type.PayMethod;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+public class ResponseApi {
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PayConfirmDto {
+        private String aid;
+        private String tid;
+        @JsonProperty("payment_method_type")
+        private PayMethod payMethod;
+
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PayReadyApiDto {
+        private String tid;
+        private String next_redirect_pc_url;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PayRefundApiDto {
+        private String aid;
+        private String tid;
+        private String status;
+        @JsonProperty("approved_cancel_amount")
+        private String approvedCancelAmount;
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/ResponseDepositPayDto.java
+++ b/pay/src/main/java/com/zerobase/model/ResponseDepositPayDto.java
@@ -1,0 +1,43 @@
+package com.zerobase.model;
+
+import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
+
+import com.zerobase.model.ResponseApi.PayReadyApiDto;
+import com.zerobase.model.type.DepositStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseDepositPayDto {
+
+    private Long postId;
+    private Long participationId;
+    private Long depositId;
+    private Long amount;
+    private DepositStatus depositStatus;
+    private String userId;
+    private String next_redirect_pc_url;
+
+
+    public static ResponseDepositPayDto from
+        (DepositDto depositDto, PayReadyApiDto payReadyApiDto) {
+        return ResponseDepositPayDto.builder()
+            .depositId(depositDto.getDepositId())
+            .postId(depositDto.getPostId())
+            .participationId(depositDto.getParticipationId())
+            .userId(depositDto.getUserId())
+            .amount(DEPOSIT_AMOUNT)
+            .depositStatus(depositDto.getDepositStatus())
+            .next_redirect_pc_url(payReadyApiDto.getNext_redirect_pc_url())
+            .build();
+
+
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/exception/CustomException.java
+++ b/pay/src/main/java/com/zerobase/model/exception/CustomException.java
@@ -1,0 +1,12 @@
+package com.zerobase.model.exception;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CustomException extends RuntimeException {
+
+}

--- a/pay/src/main/java/com/zerobase/model/type/PaymentDto.java
+++ b/pay/src/main/java/com/zerobase/model/type/PaymentDto.java
@@ -1,9 +1,6 @@
-package com.zerobase.model;
+package com.zerobase.model.type;
 
 import com.zerobase.entity.PaymentEntity;
-import com.zerobase.model.type.OrderType;
-import com.zerobase.model.type.PGMethod;
-import com.zerobase.model.type.PaymentStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;


### PR DESCRIPTION

## 🔍 PR을 통해 해결하려는 문제

- 메소드별 DTO 도입을 통해서 계층간의 데이터 이동을 유연화 및 명확화 하고자함

## 🔑 PR에서 핵심적으로 변경된 사항

**AS-IS**

계층별 dto 최초생성

**TO-BE**

- Controller 측에서 client의 request와 response에 대한 정의하여 최종적으로 client가 payready 상태의 kakao api url을 받게하고자함
- Service layer 간의 개별 dto 도입함

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
그 외 customexception 형상생성 
결제준비 외의 controller request dto 생성, 기획세부사항 결정시 적용예정

<!-- 없으면 없음으로 표기  -->

### 테스트
테스트 해당사항 없음

- [ ] 테스트 코드
<!-- 테스트 방식 상세기술 권장 --> 
    
- [ ] API 테스트 
<!-- 테스트 방식 상세기술 권장 --> 