### PR TITLE
Participation3

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -1,0 +1,45 @@
+package com.zerobase.travel.controller;
+
+import com.zerobase.travel.service.ParticipationDto;
+import com.zerobase.travel.service.ParticipationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "api/v1/posts/")
+@RestController
+@RequiredArgsConstructor
+public class ParticipationController {
+
+    private final ParticipationService participationService;
+
+    @PostMapping("{postId}/participations")
+    public ParticipationDto createParticipation(
+        @PathVariable Long postId, String userId) {
+
+        return participationService.createParticipation(postId, userId);
+
+    }
+
+
+    // 참여자 조회시에 Status에 Join과 Joinready 둘다 조회가 필요할지? 어떤 상태의 유저가 필요한지 확인필요
+    @GetMapping("{postId}/participations")
+    public ResponseEntity<List<ParticipationDto>> getParticipations(
+        @PathVariable Long postId) {
+        return ResponseEntity.ok(
+            participationService.getParticipationsStatusOfJoinAndJoinReady(postId));
+    }
+
+    // 참여취소는 정책적으로 디테일한 상의후 구현필요
+    @GetMapping("{postId}/participations{participationId}")
+    public ResponseEntity<Object> deleteParticipations() {
+        return null;
+    }
+
+
+}

--- a/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
@@ -1,0 +1,13 @@
+package com.zerobase.travel.repository;
+
+import com.zerobase.travel.entity.ParticipationEntity;
+import com.zerobase.travel.type.ParticipationStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ParticipationRepository extends JpaRepository<ParticipationEntity,Long> {
+
+    List<ParticipationEntity> findByPostEntityIdAndParticipationStatusIn(Long postId ,List<ParticipationStatus> participationStatuses);
+}

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationDto.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationDto.java
@@ -1,0 +1,30 @@
+package com.zerobase.travel.service;
+
+import com.zerobase.travel.entity.ParticipationEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParticipationDto {
+    private Long participationId;
+    private Long postId;
+    private String userId;
+
+
+    public static ParticipationDto fromEntity(ParticipationEntity participationEntity) {
+        return ParticipationDto.builder()
+            .participationId(participationEntity.getParticipationId())
+            .postId(participationEntity.getPostEntity().getPostId())
+            .userId(participationEntity.getUserId())
+            .build();
+
+    }
+
+}

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -1,0 +1,59 @@
+package com.zerobase.travel.service;
+
+import com.zerobase.travel.entity.ParticipationEntity;
+import com.zerobase.travel.type.ParticipationStatus;
+import com.zerobase.travel.entity.PostEntity;
+import com.zerobase.travel.repository.ParticipationRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ParticipationService {
+
+    private final ParticipationRepository participationRepository;
+
+    /*
+       1. 인당 최대 두개 참여가능
+       2. 최대 개수를 넘겨서는 안될것
+     */
+    public void validateApplicant() {
+
+
+    }
+
+    public ParticipationDto createParticipation(Long postId, String userId) {
+
+        this.validateApplicant();
+
+        ParticipationEntity participationEntity = ParticipationEntity.builder()
+            .postEntity(PostEntity.builder().postId(postId).build())
+            .userId(userId)
+            .participationStatus(ParticipationStatus.JOIN)
+            .build();
+
+        return ParticipationDto.fromEntity(
+            participationRepository.save(participationEntity));
+    }
+
+    public List<ParticipationDto> getParticipationsStatusOfJoinAndJoinReady(
+        Long postId) {
+
+        List<ParticipationStatus> statuses =
+            new ArrayList<>(
+                List.of(ParticipationStatus.JOIN, ParticipationStatus.JOIN));
+
+        List<ParticipationEntity> participationEntities
+            = participationRepository.findByPostEntityIdAndParticipationStatusIn(
+            postId, statuses);
+
+        return participationEntities.stream().map(ParticipationDto::fromEntity)
+            .toList();
+    }
+
+
+}


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제

Post 생성시 여행참여기능 도입

## 🔑 PR에서 핵심적으로 변경된 사항

**AS-IS**
최초도입 

**TO-BE**
1. 참여데이터 생성
2. 참여데이터 조회 : 참여데이터 조회를 위한 참여상태 세분화에 대한 논의 필요할 것으로 보임 (결제상태? 여행상태?)

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
반환 DTO 도입 : client가 직접 결제를 신청시, Deposit 결제 모듈과 Post 모듈의 이력관리를 위해서 PostId, ParticipatioinId 반환값으로 DTO에 포함 (해당 부분 기획내용 미협의)

<!-- 없으면 없음으로 표기  -->

### 테스트
기획논의 상세화 진행 후 후속 진행예정
