### PR TITLE
feat : vote validation 보강

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/exception/errorcode/VoteErrorCode.java
+++ b/travel/src/main/java/com/zerobase/travel/exception/errorcode/VoteErrorCode.java
@@ -9,7 +9,9 @@ public enum VoteErrorCode implements ErrorCode {
 
     ALREADY_VOTING_START("ERROR-VOTING-00001", "이미 투표가 시작되었습니다."),
     NOT_READY_VOTING_START("ERROR-VOTING-00002", "투표가 시작되지 않았습니다."),
-    ALREADY_VOTE("ERROR-VOTING-00003", "이미 투표 하였습니다.");
+    ALREADY_VOTE("ERROR-VOTING-00003", "이미 투표 하였습니다."),
+    ONLY_AUTHOR_CAN_START_VOTE("ERROR-VOTING-00004", "작성자만 투표를 시작할 수 있습니다."),
+    VOTE_NOT_ALLOW_THIS_POST("ERROR-VOTING-00005", "해당 게시글에 대한 투표가 아닙니다."),;
 
     private final String errorCode;
     private final String errorMessage;

--- a/travel/src/main/java/com/zerobase/travel/post/repository/PostRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/post/repository/PostRepository.java
@@ -6,5 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
+
+    boolean existsByPostIdAndUserId(long postId, long organizerUserId);
     // 추가적인 커스텀 메서드가 필요하면 여기에 작성
 }

--- a/travel/src/main/java/com/zerobase/travel/repository/VotingStartRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/VotingStartRepository.java
@@ -9,4 +9,6 @@ public interface VotingStartRepository extends JpaRepository<VotingStartEntity, 
     Optional<VotingStartEntity> findByPostId(long postId);
 
     boolean existsByPostId(long postId);
+
+    boolean existsByIdAndPostId(long votingStartsId, long postId);
 }

--- a/travel/src/test/java/com/zerobase/travel/service/VoteServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/VoteServiceTest.java
@@ -17,6 +17,7 @@ import com.zerobase.travel.entity.VotingEntity;
 import com.zerobase.travel.entity.VotingStartEntity;
 import com.zerobase.travel.exception.BizException;
 import com.zerobase.travel.exception.errorcode.VoteErrorCode;
+import com.zerobase.travel.post.repository.PostRepository;
 import com.zerobase.travel.repository.VotingRepository;
 import com.zerobase.travel.repository.VotingStartRepository;
 import com.zerobase.travel.type.VotingStatus;
@@ -37,6 +38,9 @@ class VoteServiceTest {
     private VotingStartRepository votingStartRepository;
 
     @Mock
+    private PostRepository postRepository;
+
+    @Mock
     private VotingRepository votingRepository;
 
     @InjectMocks
@@ -49,6 +53,12 @@ class VoteServiceTest {
         long userId = 2L;
 
         ArgumentCaptor<VotingStartEntity> captor = ArgumentCaptor.forClass(VotingStartEntity.class);
+
+        given(postRepository.existsByPostIdAndUserId(anyLong(), anyLong()))
+            .willReturn(true);
+
+        given(votingStartRepository.existsByPostId(anyLong()))
+            .willReturn(false);
 
         //when
         voteService.createVote(userId, postId);
@@ -101,6 +111,9 @@ class VoteServiceTest {
         //when
         given(votingStartRepository.findByPostId(anyLong()))
             .willReturn(Optional.of(votingStartEntity));
+
+        given(votingStartRepository.existsByIdAndPostId(anyLong(), anyLong()))
+            .willReturn(true);
 
         voteService.voteVoting(userId, postId, votingStartsId, approval);
 
@@ -170,12 +183,31 @@ class VoteServiceTest {
         long userId = 2L;
 
         //when
+        given(postRepository.existsByPostIdAndUserId(anyLong(), anyLong()))
+            .willReturn(true);
+
         given(votingStartRepository.existsByPostId(anyLong()))
             .willReturn(true);
 
         //then
         BizException ex = assertThrows(BizException.class, () -> voteService.createVote(userId, postId));
         assertEquals(VoteErrorCode.ALREADY_VOTING_START, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("투표 개시 실패 - 모집 게시글의 주최자가 아닙니다")
+    void createVoteFailBy주최자가아닙니다() {
+        //given
+        long postId = 1L;
+        long userId = 2L;
+
+        //when
+        given(postRepository.existsByPostIdAndUserId(anyLong(), anyLong()))
+            .willReturn(false);
+
+        //then
+        BizException ex = assertThrows(BizException.class, () -> voteService.createVote(userId, postId));
+        assertEquals(VoteErrorCode.ONLY_AUTHOR_CAN_START_VOTE, ex.getErrorCode());
     }
 
     @Test
@@ -194,12 +226,39 @@ class VoteServiceTest {
         given(votingStartRepository.findByPostId(anyLong()))
             .willReturn(Optional.of(votingStartEntity));
 
+        given(votingStartRepository.existsByIdAndPostId(anyLong(), anyLong()))
+            .willReturn(true);
+
         given(votingRepository.existsByUserIdAndVotingStartEntity(anyLong(), any()))
             .willReturn(true);
 
         //then
         BizException ex = assertThrows(BizException.class, () -> voteService.voteVoting(userId, postId, votingStartsId, approval));
         assertEquals(VoteErrorCode.ALREADY_VOTE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("투표 실패 - 게시글에 해당하는 투표가 아님")
+    void voteVotingFailBy게시글에해당하는투표가아님() {
+        //given
+        long postId = 1L;
+        long userId = 2L;
+        long votingStartsId = 1L;
+        boolean approval = true;
+
+        VotingStartEntity votingStartEntity = VotingStartEntity.builder()
+            .build();
+
+        //when
+        given(votingStartRepository.findByPostId(anyLong()))
+            .willReturn(Optional.of(votingStartEntity));
+
+        given(votingStartRepository.existsByIdAndPostId(anyLong(), anyLong()))
+            .willReturn(false);
+
+        //then
+        BizException ex = assertThrows(BizException.class, () -> voteService.voteVoting(userId, postId, votingStartsId, approval));
+        assertEquals(VoteErrorCode.VOTE_NOT_ALLOW_THIS_POST, ex.getErrorCode());
     }
 
 }

--- a/travel/src/test/java/com/zerobase/travel/service/VoteServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/VoteServiceTest.java
@@ -182,10 +182,10 @@ class VoteServiceTest {
         long postId = 1L;
         long userId = 2L;
 
-        //when
         given(postRepository.existsByPostIdAndUserId(anyLong(), anyLong()))
             .willReturn(true);
 
+        //when
         given(votingStartRepository.existsByPostId(anyLong()))
             .willReturn(true);
 
@@ -222,13 +222,13 @@ class VoteServiceTest {
         VotingStartEntity votingStartEntity = VotingStartEntity.builder()
             .build();
 
-        //when
         given(votingStartRepository.findByPostId(anyLong()))
             .willReturn(Optional.of(votingStartEntity));
 
         given(votingStartRepository.existsByIdAndPostId(anyLong(), anyLong()))
             .willReturn(true);
 
+        //when
         given(votingRepository.existsByUserIdAndVotingStartEntity(anyLong(), any()))
             .willReturn(true);
 
@@ -249,10 +249,10 @@ class VoteServiceTest {
         VotingStartEntity votingStartEntity = VotingStartEntity.builder()
             .build();
 
-        //when
         given(votingStartRepository.findByPostId(anyLong()))
             .willReturn(Optional.of(votingStartEntity));
 
+        //when
         given(votingStartRepository.existsByIdAndPostId(anyLong(), anyLong()))
             .willReturn(false);
 


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
vote 기능에 validation을 보완하여 비즈니스에 알맞게 한다.

## 🔑 PR에서 핵심적으로 변경된 사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
- 투표 시작시 모집글 작성자만 가능하도록 validation한다.
- 투표 시 게시글ID에 맞는 투표ID인지 확인하여 다른 투표, 다른 게시글에 투표하지 못하도록 validation한다.

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 없음으로 표기  -->
없음

### 테스트
<!-- 테스트 방식 상세기술 권장 --> 
- createVote 시 post table에 postId, userId에 해당하는 로우가 없으면 
   BizException(VoteErrorCode.ONLY_AUTHOR_CAN_START_VOTE) 

- voteVoting 시 votingStart 테이블에 votingStartId, postId에 해당하는 로우가 없으면
   BizException(VoteErrorCode.VOTE_NOT_ALLOW_THIS_POST) 