### PR TITLE
feat) payservice deposit entity 변경 및 서비스 결제확정, 취소 기능 추가

### DIFF
--- a/pay/src/main/java/com/zerobase/controller/PayController.java
+++ b/pay/src/main/java/com/zerobase/controller/PayController.java
@@ -2,13 +2,20 @@ package com.zerobase.controller;
 
 import com.zerobase.model.RequestReadyPayDeposit;
 import com.zerobase.model.ResponseDepositPayDto;
+import com.zerobase.model.ResponsePaymentDto;
+import com.zerobase.model.type.PaymentDto;
 import com.zerobase.service.PayManagementService;
+import com.zerobase.service.PaymentService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,24 +32,39 @@ import org.springframework.web.bind.annotation.RestController;
 public class PayController {
 
     private final PayManagementService payManagmentService;
+    private final PaymentService paymentService;
+
+
+    @GetMapping(value = "/list")
+    public ResponseEntity<List<ResponsePaymentDto>> getPayHistory(
+        @RequestHeader String userId) {
+
+        List<PaymentDto> paymentDtos = paymentService.getPayments(userId);
+        return ResponseEntity.ok(
+            paymentDtos.stream().map(ResponsePaymentDto::fromDto).toList());
+    }
 
     // 결제시도후 payDeposit 생성하기
     @PostMapping(value = "/deposit/ready")
     public ResponseEntity<ResponseDepositPayDto> readyPayDeposit(
         @RequestBody RequestReadyPayDeposit request) {
         log.info("request ready pay deposit {}", request.toString());
-        return ResponseEntity.ok(payManagmentService.createDepositOrderAndInitiatePay(
-            request.getPostId(),
-            request.getParticipationId(), request.getUserId(),
-            request.getPgMethod()))
+        return ResponseEntity.ok(
+            payManagmentService.createDepositOrderAndInitiatePay(
+                request.getPostId(),
+                request.getParticipationId(), request.getUserId(),
+                request.getPgMethod()))
             ;
 
     }
 
     // client 결제성공시 url 신호받기
     @GetMapping(value = "/deposit/success")
-    public ResponseEntity<Object> PayDepositSuccess(@RequestParam("pg_token") String pgToken) {
+    public ResponseEntity<Object> PayDepositSuccess(
+        @RequestParam("pg_token") String pgToken,
+        @RequestHeader("userId") String usderId) {
         log.info(" pay deposit success sign from client");
+        payManagmentService.successDepositPay(usderId, pgToken);
 
         return null;
     }
@@ -50,31 +72,20 @@ public class PayController {
 
     // client 결제실패시 url 신호받기
     @GetMapping(value = "/deposit/fail")
-    public ResponseEntity<Object> PayDepositFail() {
+    public ResponseEntity<Object> PayDepositFail(
+        @RequestHeader("userId") String usderId
+    ) {
         log.info(" pay deposit fail sign from client");
+        payManagmentService.failedDepositPay(usderId);
 
         return null;
     }
 
     // client 결제환불시 url 신호받기
-    @GetMapping(value = "/deposit/refund")
-    public ResponseEntity<Object> PayDepositRefund() {
+    @GetMapping(value = "/deposit/byParticipation/{participtionId}/refund")
+    public ResponseEntity<Object> PayDepositRefund(@PathVariable Long participtionId) {
         log.info(" pay deposit refund sign from client");
-
-        return null;
-    }
-
-
-    @GetMapping(value = "/deposit")
-    public ResponseEntity<Object> getPayDeposit(
-        @RequestParam String userId, @RequestParam Long postId) {
-
-        return null;
-    }
-
-    @GetMapping
-    public ResponseEntity<Object> getPayHistory() {
-
+        payManagmentService.refundDepositPay(participtionId);
         return null;
     }
 

--- a/pay/src/main/java/com/zerobase/entity/DepositEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/DepositEntity.java
@@ -1,6 +1,5 @@
 package com.zerobase.entity;
 
-import com.zerobase.model.type.DepositStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -25,6 +24,4 @@ public class DepositEntity {
     private Long postId;
     private Long participationId;
     private String userId;
-
-    private DepositStatus depositStatus;
 }

--- a/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
@@ -27,11 +27,14 @@ public class PaymentEntity {
     private String paykey;
     private String userId;
     private Long amount;
+    // 결제라는 개념이 단순히 deposit에 종속된 개념이 아니라 deposit을 포함하는 상위개념으로
+    // 취급하기 위해서 depositstatus 와 별개로 Paymentstatus 를 두고 관리함. 다른 아이템에 확장가능하도록.
     private PaymentStatus paymentStatus;
     private PGMethod pgMethod;
+
     // 여기서는 deposit
     private OrderType referencialOrderType;
-    // 여기서는 현재, deposit_id
+    // 여기서는 deposit_id
     private Long referentialOrderId;
 
 }

--- a/pay/src/main/java/com/zerobase/model/DepositDto.java
+++ b/pay/src/main/java/com/zerobase/model/DepositDto.java
@@ -1,8 +1,6 @@
 package com.zerobase.model;
 
 import com.zerobase.entity.DepositEntity;
-import com.zerobase.model.type.DepositStatus;
-import com.zerobase.model.type.PGMethod;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +17,6 @@ public class DepositDto {
     private Long postId;
     private Long participationId;
     private String userId;
-    private DepositStatus depositStatus;
 
     public static DepositDto fromEntity(DepositEntity entity) {
         return DepositDto.builder()
@@ -27,8 +24,6 @@ public class DepositDto {
             .postId(entity.getPostId())
             .participationId(entity.getParticipationId())
             .userId(entity.getUserId())
-
-            .depositStatus(entity.getDepositStatus())
             .build();
     }
 }

--- a/pay/src/main/java/com/zerobase/model/RequestApi.java
+++ b/pay/src/main/java/com/zerobase/model/RequestApi.java
@@ -20,12 +20,6 @@ public class RequestApi {
 
         private String tid;
 
-        @JsonProperty("total_amount")
-        private String totalAmount;
-
-        @JsonProperty("tax_free_amount")
-        private String taxFreeAmount;
-
 
         @JsonProperty("partner_order_id")
         private String partnerOrderId;

--- a/pay/src/main/java/com/zerobase/model/ResponseDepositPayDto.java
+++ b/pay/src/main/java/com/zerobase/model/ResponseDepositPayDto.java
@@ -3,7 +3,6 @@ package com.zerobase.model;
 import static com.zerobase.config.Constants.DEPOSIT_AMOUNT;
 
 import com.zerobase.model.ResponseApi.PayReadyApiDto;
-import com.zerobase.model.type.DepositStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +20,6 @@ public class ResponseDepositPayDto {
     private Long participationId;
     private Long depositId;
     private Long amount;
-    private DepositStatus depositStatus;
     private String userId;
     private String next_redirect_pc_url;
 
@@ -34,7 +32,6 @@ public class ResponseDepositPayDto {
             .participationId(depositDto.getParticipationId())
             .userId(depositDto.getUserId())
             .amount(DEPOSIT_AMOUNT)
-            .depositStatus(depositDto.getDepositStatus())
             .next_redirect_pc_url(payReadyApiDto.getNext_redirect_pc_url())
             .build();
 

--- a/pay/src/main/java/com/zerobase/model/ResponsePaymentDto.java
+++ b/pay/src/main/java/com/zerobase/model/ResponsePaymentDto.java
@@ -1,0 +1,38 @@
+package com.zerobase.model;
+
+import com.zerobase.model.type.OrderType;
+import com.zerobase.model.type.PGMethod;
+import com.zerobase.model.type.PaymentDto;
+import com.zerobase.model.type.PaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponsePaymentDto {
+
+    private OrderType referencialOrderType;
+    private Long referentialOrderId;
+    private Long amount;
+    private PaymentStatus paymentStatus;
+    private PGMethod pgMethod;
+
+
+    public static ResponsePaymentDto fromDto(PaymentDto paymentDto) {
+        return ResponsePaymentDto.builder()
+            .referencialOrderType(paymentDto.getReferencialOrderType())
+            .referentialOrderId(paymentDto.getReferentialOrderId())
+            .amount(paymentDto.getAmount())
+            .pgMethod(paymentDto.getPgMethod())
+            .paymentStatus(paymentDto.getPaymentStatus())
+            .build();
+
+
+    }
+}

--- a/pay/src/main/java/com/zerobase/model/type/DepositStatus.java
+++ b/pay/src/main/java/com/zerobase/model/type/DepositStatus.java
@@ -1,8 +1,0 @@
-package com.zerobase.model.type;
-
-public enum DepositStatus {
-    PAID,
-    REFUNDED,
-    BEFORE_PAYMENT,
-    FAILED
-}

--- a/pay/src/main/java/com/zerobase/model/type/PaymentDto.java
+++ b/pay/src/main/java/com/zerobase/model/type/PaymentDto.java
@@ -25,6 +25,7 @@ public class PaymentDto {
             .referencialOrderType(paymentEntity.getReferencialOrderType())
             .referentialOrderId(paymentEntity.getReferentialOrderId())
             .userId(paymentEntity.getUserId())
+            .payKey(paymentEntity.getPaykey())
             .amount(paymentEntity.getAmount())
             .pgMethod(paymentEntity.getPgMethod())
             .paymentStatus(paymentEntity.getPaymentStatus())

--- a/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
+++ b/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
@@ -1,6 +1,9 @@
 package com.zerobase.repository;
 
 import com.zerobase.entity.PaymentEntity;
+import com.zerobase.model.type.PaymentStatus;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +16,7 @@ public interface PaymentRepository extends JpaRepository<PaymentEntity,Long> {
     Optional<PaymentEntity> findByReferentialOrderId(Long referentialOrderId);
 
 
+    Optional<PaymentEntity> findByUserIdAndPaymentStatus(String usderId, PaymentStatus paymentStatus);
+
+    List<PaymentEntity> findAllByUserId(String userId);
 }

--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -3,7 +3,6 @@ package com.zerobase.service;
 import com.zerobase.entity.DepositEntity;
 import com.zerobase.model.DepositDto;
 import com.zerobase.model.exception.CustomException;
-import com.zerobase.model.type.DepositStatus;
 import com.zerobase.repository.DepositRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +17,6 @@ public class DepositService {
     private final DepositRepository depositRepository;
 
 
-
-
-
     // depositId를 생성하기 위해서
     public DepositDto createDepositOrder(Long postId, Long participationId,
         String userId) {
@@ -30,39 +26,15 @@ public class DepositService {
             .postId(postId)
             .participationId(participationId)
             .userId(userId)
-            .depositStatus(DepositStatus.BEFORE_PAYMENT)
             .build();
 
         return DepositDto.fromEntity(depositRepository.save(depositEntity));
     }
 
 
-
-/*
-    public void changeStatusToCompleteByOrderId(Long referentialOrderId) {
-        DepositEntity depositEntity = depositRepository.findById(
-            referentialOrderId).orElseThrow(
-            () -> new CustomException());
-
-        depositEntity.setDepositStatus(DepositStatus.PAID);
+    public DepositDto findByParticipationId(Long participationId) {
+        return DepositDto.fromEntity(depositRepository
+            .findByParticipationId(participationId).orElseThrow(
+            CustomException::new));
     }
-
-    public void changeStatusToFailByOrderId(Long referentialOrderId) {
-        DepositEntity depositEntity = depositRepository.findById(
-            referentialOrderId).orElseThrow(
-            () -> new CustomException());
-
-        depositEntity.setDepositStatus(DepositStatus.FAILED);
-    }
-
-    public DepositDto changeStatusToRefundedByParticipationId(Long participationId) {
-
-        DepositEntity depositEntity = depositRepository.findByParticipationId(
-            participationId).orElseThrow(() -> new CustomException());
-
-        depositEntity.setDepositStatus(DepositStatus.REFUNDED);
-    return null;
-    }
-
- */
 }

--- a/pay/src/main/java/com/zerobase/service/KakaopayApiService.java
+++ b/pay/src/main/java/com/zerobase/service/KakaopayApiService.java
@@ -66,7 +66,7 @@ public class KakaopayApiService implements ApiService {
         return payReadyApiDto;
     }
 
-    /*
+
 
     public ResponseApi.PayConfirmDto sendPayConfirmSign(
         String tid, Long orderId, String userId, String pgToken) {
@@ -130,7 +130,7 @@ public class KakaopayApiService implements ApiService {
     }
 
 
-     */
+
 }
 
 

--- a/pay/src/test/resources/payAPITest.http
+++ b/pay/src/test/resources/payAPITest.http
@@ -6,9 +6,64 @@ Content-Type: application/json
   "postId": "1234",
   "participationId": "1234",
   "userId": "userid",
-  "paymentMethod": "KAKAOPAY"
+  "pgMethod": "KAKAOPAY"
 }
 
+###
+# curl --location 'https://open-api.kakaopay.com/online/v1/payment/ready'
+#--header 'Authorization: SECRET_KEY ${SECRET_KEY}'
+#--header 'Content-Type: application/json'
+#--data '{
+#		"cid": "TC0ONETIME",
+#		"partner_order_id": "partner_order_id",
+#		"partner_user_id": "partner_user_id",
+#		"item_name": "초코파이",
+#		"quantity": "1",
+#		"total_amount": "2200",
+#		"vat_amount": "200",
+#		"tax_free_amount": "0",
+#		"approval_url": "https://developers.kakao.com/success",
+#		"fail_url": "https://developers.kakao.com/fail",
+#		"cancel_url": "https://developers.kakao.com/cancel"
+#	}'
+POST https://open-api.kakaopay.com/online/v1/payment/ready
+Authorization: SECRET_KEY DEVBB2EC55AEA5209485B283C6EAC15502C4B307
+Content-Type: application/json
+
+{
+  "cid": "TC0ONETIME",
+  "partner_order_id": "partner_order_id",
+  "partner_user_id": "partner_user_id",
+  "item_name": "초코파이",
+  "quantity": "1",
+  "total_amount": "2200",
+  "vat_amount": "200",
+  "tax_free_amount": "0",
+  "approval_url": "http://localhost:8080/api/v1/pay/deposit/success",
+  "fail_url": "http://localhost:8080/api/v1/pay/deposit/success",
+  "cancel_url": "http://localhost:8080/api/v1/pay/deposit/success"
+}
+
+### 결제내역 조회하기
+
+GET http://localhost:8080/api/v1/pay/list
+userId: userid
+
+### 성공사인 보내기 ; token은 매 요청마다 변경됨
+http://localhost:8080/api/v1/pay/deposit/success?pg_token=1c980ca5770210f6106f
+userId: userid
 
 
+### 성공사인 보내기 ; token은 매 요청마다 변경됨
+POST https://open-api.kakaopay.com/online/v1/payment/approve
+Authorization: SECRET_KEY DEVBB2EC55AEA5209485B283C6EAC15502C4B307
+Content-Type: application/json
+
+{
+    "cid": "TC0ONETIME",
+    "tid": "T72ab85d05806393ef3d",
+    "partner_order_id": "1",
+    "partner_user_id": "userid",
+    "pg_token": "405f73dc664fd6c8694c"
+}
 


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제

비즈니스 기획 구체화로 인해서 Deposit의 status 관리가 필요 없어짐
-> deposit 객체 생성시점과 결제완료 시점이 동일해짐
-> deposit은 주문의 개념이므로 deposit의 반환여부는 participation객체 에서 관리

Payservice의 결제내역조회, 결제확정기능 등 신규도입과 코드 일부수정


## 🔑 PR에서 핵심적으로 변경된 사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->


**AS-IS**
1. Deposit의 생성후 결제이전, 결제완료, 환불완료로 관리함

**TO-BE**
1. Deposit생성시점과 결제시점이 동일한 트랜잭션으로 처리하기로 결정되어 Desposit의 status 값 삭제
2. PayService 결제확정기능 도입
3. PayService 결제내역조회

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분


<!-- 없으면 없음으로 표기  -->

### 테스트
- [ ] 테스트 코드
<!-- 테스트 방식 상세기술 권장 --> 
    
- [x] API 테스트 
<!-- 테스트 방식 상세기술 권장 --> 
결제준비, 결제내역확인, 결제확정처리 기능 동작확인
