### PR TITLE
jwt 토큰에 userId 필드 추가, apigateway에서 userId를 헤더에 포함시켜 넘겨주기 위함

### DIFF
--- a/gateway/src/main/java/com/zerobase/gateway/jwt/JwtGatewayFilterFactory.java
+++ b/gateway/src/main/java/com/zerobase/gateway/jwt/JwtGatewayFilterFactory.java
@@ -42,12 +42,14 @@ public class JwtGatewayFilterFactory extends
                 // 이메일과 역할 정보를 추출하여 헤더에 추가
                 String email = jwtUtil.getEmail(accessToken);
                 String role = jwtUtil.getRole(accessToken);
+                String userId = jwtUtil.getUserId(accessToken);
 
                 // 기존 헤더를 복사하고 새로운 헤더를 추가
                 HttpHeaders headers = new HttpHeaders();
                 headers.putAll(exchange.getRequest().getHeaders());
                 headers.add("X-User-Email", email);
                 headers.add("X-User-Role", role);
+                headers.add("X-User-Id", userId);
 
                 // 새로운 ServerHttpRequestDecorator를 생성하여 헤더를 교체
                 ServerHttpRequest mutatedRequest = new ServerHttpRequestDecorator(exchange.getRequest()) {

--- a/gateway/src/main/java/com/zerobase/gateway/util/JWTUtil.java
+++ b/gateway/src/main/java/com/zerobase/gateway/util/JWTUtil.java
@@ -28,6 +28,11 @@ public class JWTUtil {
         return claims.get("email", String.class);
     }
 
+    public String getUserId(String token) {
+        Claims claims = parseToken(token);
+        return claims.get("userId", String.class);
+    }
+
     // 토큰에서 역할(Role)을 추출하는 메서드
     public String getRole(String token) {
         Claims claims = parseToken(token);

--- a/user/src/main/java/com/zerobase/user/dto/response/BasicErrorCode.java
+++ b/user/src/main/java/com/zerobase/user/dto/response/BasicErrorCode.java
@@ -21,7 +21,8 @@ public enum BasicErrorCode implements ErrorCode {
     AUTHENTICATION_CODE_EXPIRED_ERROR("E01026", "인증 코드가 만료되었습니다."),
     INVALID_AUTHENTICATION_CODE_ERROR("E01027", "인증 코드가 유효하지 않습니다."),
     ILLEGAL_EMAIL_ADDRESS_ERROR("E01028", "잘못된 이메일 주소"),
-    EMAIL_SENDING_ERROR("E01029", "이메일 전송 실패");
+    EMAIL_SENDING_ERROR("E01029", "이메일 전송 실패"),
+    CREATE_TOKEN_ERROR("E01030", "토큰 생성 중 오류가 발생했습니다.");
 
     private final String errorCode;
     private final String errorMessage;

--- a/user/src/main/java/com/zerobase/user/jwt/LoginFilter.java
+++ b/user/src/main/java/com/zerobase/user/jwt/LoginFilter.java
@@ -1,7 +1,6 @@
 package com.zerobase.user.jwt;
 
 import static com.zerobase.user.dto.response.BasicErrorCode.CREATE_TOKEN_ERROR;
-import static com.zerobase.user.dto.response.BasicErrorCode.ILLEGAL_ARGUMENT__ERROR;
 import static com.zerobase.user.dto.response.BasicErrorCode.INTERNAL_SERVER_ERROR;
 import static com.zerobase.user.dto.response.ValidErrorCode.LOGIN_FAIL_ERROR;
 import static com.zerobase.user.dto.response.ValidErrorCode.USER_NOT_FOUND_ERROR;
@@ -100,17 +99,17 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Long userEntityId = userEntity.getId();
 
         try {
-        //토큰 생성
-        String access = jwtUtil.createJwt("access", email, role, 1800000L, userEntityId);
-        String refresh = jwtUtil.createJwt("refresh", email, role, 86400000L, userEntityId);
-        log.info("Generated access and refresh tokens for user: {}", email);
+            //토큰 생성
+            String access = jwtUtil.createJwt("access", email, role, 1800000L, userEntityId);
+            String refresh = jwtUtil.createJwt("refresh", email, role, 86400000L, userEntityId);
+            log.info("Generated access and refresh tokens for user: {}", email);
 
-        //Refresh 토큰 저장
-        addRefreshEntity(email, refresh, 86400000L);
+            //Refresh 토큰 저장
+            addRefreshEntity(email, refresh, 86400000L);
 
-        //응답 설정
-        response.setHeader("access", access);
-        response.addCookie(cookieUtil.createCookie("refresh", refresh));
+            //응답 설정
+            response.setHeader("access", access);
+            response.addCookie(cookieUtil.createCookie("refresh", refresh));
 
             // JSON 응답 생성
 
@@ -125,10 +124,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
                 .build();
 
             ResponseUtil.setJsonResponse(response, HttpServletResponse.SC_OK, loginSuccessDTO);
-        } catch (IOException e) {
-            log.error("Failed to write the response", e);
-            throw new BizException(ILLEGAL_ARGUMENT__ERROR);
-        }catch (JwtException e) { // jwtUtil.createJwt(...) 에서 발생할 수 있는 예외
+        } catch (JwtException e) { // jwtUtil.createJwt(...) 에서 발생할 수 있는 예외
             log.error("Failed to create JWT token", e);
             throw new BizException(CREATE_TOKEN_ERROR);
         } catch (Exception e) { // 기타 모든 예외

--- a/user/src/main/java/com/zerobase/user/jwt/LoginFilter.java
+++ b/user/src/main/java/com/zerobase/user/jwt/LoginFilter.java
@@ -1,6 +1,10 @@
 package com.zerobase.user.jwt;
 
+import static com.zerobase.user.dto.response.BasicErrorCode.CREATE_TOKEN_ERROR;
+import static com.zerobase.user.dto.response.BasicErrorCode.ILLEGAL_ARGUMENT__ERROR;
+import static com.zerobase.user.dto.response.BasicErrorCode.INTERNAL_SERVER_ERROR;
 import static com.zerobase.user.dto.response.ValidErrorCode.LOGIN_FAIL_ERROR;
+import static com.zerobase.user.dto.response.ValidErrorCode.USER_NOT_FOUND_ERROR;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.user.dto.request.LoginRequestDTO;
@@ -8,12 +12,14 @@ import com.zerobase.user.dto.response.LoginSuccessDTO;
 import com.zerobase.user.entity.ProfileEntity;
 import com.zerobase.user.entity.RefreshEntity;
 import com.zerobase.user.entity.UserEntity;
+import com.zerobase.user.exception.BizException;
 import com.zerobase.user.repository.ProfileRepository;
 import com.zerobase.user.repository.RefreshRepository;
 import com.zerobase.user.repository.UserRepository;
 import com.zerobase.user.util.CookieUtil;
 import com.zerobase.user.util.JWTUtil;
 import com.zerobase.user.util.ResponseUtil;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -89,9 +95,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         GrantedAuthority auth = iterator.next();
         String role = auth.getAuthority();
 
+        UserEntity userEntity = userRepository.findByEmail(email)
+            .orElseThrow(() -> new BizException(USER_NOT_FOUND_ERROR));
+        Long userEntityId = userEntity.getId();
+
+        try {
         //토큰 생성
-        String access = jwtUtil.createJwt("access", email, role, 1800000L);
-        String refresh = jwtUtil.createJwt("refresh", email, role, 86400000L);
+        String access = jwtUtil.createJwt("access", email, role, 1800000L, userEntityId);
+        String refresh = jwtUtil.createJwt("refresh", email, role, 86400000L, userEntityId);
         log.info("Generated access and refresh tokens for user: {}", email);
 
         //Refresh 토큰 저장
@@ -101,11 +112,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setHeader("access", access);
         response.addCookie(cookieUtil.createCookie("refresh", refresh));
 
-        try {
             // JSON 응답 생성
-            Optional<UserEntity> OptionalUserEntity = userRepository.findByEmail(email);
-            UserEntity userEntity = OptionalUserEntity.get();
-            Long userEntityId = userEntity.getId();
 
             Optional<ProfileEntity> OptionalProfileEntity = profileRepository.findByUserId(
                 userEntityId);
@@ -120,6 +127,13 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             ResponseUtil.setJsonResponse(response, HttpServletResponse.SC_OK, loginSuccessDTO);
         } catch (IOException e) {
             log.error("Failed to write the response", e);
+            throw new BizException(ILLEGAL_ARGUMENT__ERROR);
+        }catch (JwtException e) { // jwtUtil.createJwt(...) 에서 발생할 수 있는 예외
+            log.error("Failed to create JWT token", e);
+            throw new BizException(CREATE_TOKEN_ERROR);
+        } catch (Exception e) { // 기타 모든 예외
+            log.error("Unexpected error during authentication", e);
+            throw new BizException(INTERNAL_SERVER_ERROR);
         }
 
         log.debug("Access and refresh tokens sent in response for user: {}", email);

--- a/user/src/main/java/com/zerobase/user/util/JWTUtil.java
+++ b/user/src/main/java/com/zerobase/user/util/JWTUtil.java
@@ -24,6 +24,11 @@ public class JWTUtil {
             .get("email", String.class);
     }
 
+    public String getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+            .get("userId", String.class);
+    }
+
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
             .get("role", String.class);
@@ -40,12 +45,13 @@ public class JWTUtil {
             .get("category", String.class);
     }
 
-    public String createJwt(String category, String email, String role, Long expiredMs) {
+    public String createJwt(String category, String email, String role, Long expiredMs, Long userId) {
 
         return Jwts.builder()
             .claim("category", category)
             .claim("email", email)
             .claim("role", role)
+            .claim("userId", userId.toString())
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(System.currentTimeMillis() + expiredMs))
             .signWith(secretKey)


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
기존 apigateway에서 토큰을 통해 사용자 email을 헤더에서 꺼내서 user 모듈쪽으로 feignClient써서 사용자 정보를 가져오는 구조에서
애초에 토큰에 uesrId 넣어두면 userId만 필요한 컨트롤러에서 feignClient로 사용자 정보를 user모듈쪽에서 가져올 필요가 없음.

## 🔑 PR에서 핵심적으로 변경된 사항
jwt 토큰에 userId 필드 추가, apigateway에서 userId를 헤더에 포함시켜 넘겨주기 위함

