### PR TITLE
feat : 후기 단건 조회 기능 개발

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/controller/ReviewController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ReviewController.java
@@ -2,10 +2,12 @@ package com.zerobase.travel.controller;
 
 import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.dto.request.ReviewRequestDto;
+import com.zerobase.travel.dto.response.ReviewResponseDto;
 import com.zerobase.travel.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -58,6 +60,17 @@ public class ReviewController {
         reviewService.deleteReview(userEmail, postId, reviewId);
 
         return ResponseEntity.ok(ResponseMessage.success());
+    }
+
+    @GetMapping("/posts/{postId}/reviews/{reviewId}")
+    public ResponseEntity<ResponseMessage<ReviewResponseDto.Review>> getReview(
+        @PathVariable long postId,
+        @PathVariable long reviewId
+
+    ) {
+        return ResponseEntity.ok(ResponseMessage.success(
+            reviewService.getReview(postId, reviewId)
+        ));
     }
 
 }

--- a/travel/src/main/java/com/zerobase/travel/dto/response/ReviewResponseDto.java
+++ b/travel/src/main/java/com/zerobase/travel/dto/response/ReviewResponseDto.java
@@ -1,0 +1,66 @@
+package com.zerobase.travel.dto.response;
+
+import com.zerobase.travel.entity.ReviewEntity;
+import com.zerobase.travel.entity.ReviewFileEntity;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+public class ReviewResponseDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class Review {
+
+        private Long reviewId;
+        private Long postId;
+        private Long userId;
+        private String continent;
+        private String country;
+        private String region;
+        private String title;
+        private String contents;
+
+        private List<ReviewFile> files;
+
+        public static Review fromEntity(ReviewEntity entity) {
+            return Review.builder()
+                .reviewId(entity.getId())
+                .postId(entity.getPostId())
+                .userId(entity.getUserId())
+                .continent(entity.getContinent().toString())
+                .country(entity.getCountry().toString())
+                .region(entity.getRegion())
+                .title(entity.getTitle())
+                .contents(entity.getContents())
+                .files(
+                    entity.getReviewFileList().stream()
+                        .map(ReviewFile::fromEntity)
+                        .toList()
+                )
+                .build();
+        }
+
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class ReviewFile {
+
+        private String fileAddress;
+
+        public static ReviewFile fromEntity(ReviewFileEntity entity) {
+            return ReviewFile.builder()
+                .fileAddress(entity.getFileAddress())
+                .build();
+        }
+    }
+
+
+}

--- a/travel/src/main/java/com/zerobase/travel/entity/ReviewEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/entity/ReviewEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -49,7 +50,7 @@ public class ReviewEntity {
     private String contents;
 
     @Builder.Default
-    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<ReviewFileEntity> reviewFileList = new ArrayList<>();
 
     public void addReviewFile(ReviewFileEntity reviewFileEntity) {

--- a/travel/src/main/java/com/zerobase/travel/exception/errorcode/ReviewErrorCode.java
+++ b/travel/src/main/java/com/zerobase/travel/exception/errorcode/ReviewErrorCode.java
@@ -9,7 +9,7 @@ public enum ReviewErrorCode implements ErrorCode {
 
     ALREADY_WRITE_REVIEW("ERROR-REVIEW-00001", "후기를 이미 작성하였습니다."),
     NOT_MY_REVIEW("ERROR-REVIEW-00002", "내가 작성한 후기가 아닙니다."),
-    THIS_REVIEW_NOT_IN_POST("ERROR-REVIEW-00003", "여행을 갔다온 게시글의 후기가 아닙니다."),
+    THIS_REVIEW_NOT_IN_POST("ERROR-REVIEW-00003", "모집 게시글에 대한 후기가 아닙니다."),
     NOT_FOUND_REVIEW("ERROR-REVIEW-00004", "후기를 찾을 수 없습니다.");
 
     private final String errorCode;

--- a/travel/src/main/java/com/zerobase/travel/service/ReviewService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.zerobase.travel.service;
 import com.zerobase.travel.dto.request.ReviewRequestDto.CreateReview;
 import com.zerobase.travel.dto.request.ReviewRequestDto.ModifyReview;
 import com.zerobase.travel.dto.request.ReviewRequestDto.ModifyReview.File;
+import com.zerobase.travel.dto.response.ReviewResponseDto;
 import com.zerobase.travel.entity.ReviewEntity;
 import com.zerobase.travel.exception.BizException;
 import com.zerobase.travel.exception.errorcode.ReviewErrorCode;
@@ -73,6 +74,24 @@ public class ReviewService {
             .orElseThrow(() -> new BizException(ReviewErrorCode.NOT_FOUND_REVIEW));
 
         reviewRepository.delete(review);
+    }
+
+    public ReviewResponseDto.Review getReview(long postId, long reviewId) {
+
+        ReviewEntity review = reviewRepository.findById(reviewId)
+            .orElseThrow(() -> new BizException(ReviewErrorCode.NOT_FOUND_REVIEW));
+
+        validationGetReview(reviewId, postId);
+        
+        return ReviewResponseDto.Review.fromEntity(review);
+
+    }
+
+    private void validationGetReview(long reviewId, long postId) {
+        //가져오려는 후기가 postid에 해당하는 후기인지
+        if (!reviewRepository.existsByIdAndPostId(reviewId, postId)) {
+            throw new BizException(ReviewErrorCode.THIS_REVIEW_NOT_IN_POST);
+        }
     }
 
     private void validationCreateReview(long userId, long postId) {

--- a/travel/src/test/java/com/zerobase/travel/controller/ReviewControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/controller/ReviewControllerTest.java
@@ -2,10 +2,12 @@ package com.zerobase.travel.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -13,7 +15,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.travel.dto.request.ReviewRequestDto;
+import com.zerobase.travel.dto.response.ReviewResponseDto;
 import com.zerobase.travel.service.ReviewService;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,6 +130,55 @@ class ReviewControllerTest {
             .andExpect(jsonPath("$.result").value("SUCCESS"));
 
         verify(reviewService, times(1)).deleteReview(any(), anyLong(), anyLong());
+
+    }
+
+    @Test
+    @WithMockUser
+    void successGetReview() throws Exception {
+
+        //given
+        ReviewResponseDto.Review getReview = ReviewResponseDto.Review.builder()
+            .reviewId(1L)
+            .postId(2L)
+            .userId(3L)
+            .continent(Continent.AFRICA.toString())
+            .country(Country.KR.toString())
+            .region("서울")
+            .title("서울 여행")
+            .contents("서울여행 좋아요.")
+            .files(
+                List.of(
+                    ReviewResponseDto.ReviewFile.builder()
+                        .fileAddress("/asd/asd/asd")
+                        .build(),
+                    ReviewResponseDto.ReviewFile.builder()
+                        .fileAddress("/zxc/zxc/zxc")
+                        .build()
+                )
+            )
+            .build();
+
+        given(reviewService.getReview(anyLong(), anyLong()))
+            .willReturn(getReview);
+
+        //when
+        //then
+        mockMvc.perform(get("/api/v1/posts/{postId}/reviews/{reviewId}", 1L, 2L))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result").value("SUCCESS"))
+            .andExpect(jsonPath("$.data.reviewId").value(1L))
+            .andExpect(jsonPath("$.data.postId").value(2L))
+            .andExpect(jsonPath("$.data.userId").value(3L))
+            .andExpect(jsonPath("$.data.continent").value(Continent.AFRICA.toString()))
+            .andExpect(jsonPath("$.data.country").value(Country.KR.toString()))
+            .andExpect(jsonPath("$.data.region").value("서울"))
+            .andExpect(jsonPath("$.data.title").value("서울 여행"))
+            .andExpect(jsonPath("$.data.contents").value("서울여행 좋아요."))
+            .andExpect(jsonPath("$.data.files[0].fileAddress").value("/asd/asd/asd"))
+            .andExpect(jsonPath("$.data.files[1].fileAddress").value("/zxc/zxc/zxc"));
+
+        verify(reviewService, times(1)).getReview(anyLong(), anyLong());
 
     }
 }


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
후기 단건 조회 기능 개발

## 🔑 PR에서 핵심적으로 변경된 사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
- 후기 단건 조회 기능 개발

- ReviewEntity fetchType.EAGER 로변경
  review 가져올때 대부분 file정보도 필요할것으로 예상되어 EAGER로 변경

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 없음으로 표기  -->
- ErrorCode 의 message 내용 수정

## 📊 테스트
<!-- 테스트 방식 상세기술 권장 --> 
- 후기 단건 조회 controller 테스트
  - 성공
  - 성공시 result : success 이고 return value 가 given 절과 동일하면 성공

- 후기  단건 조회 service 테스트
  - 성공
    - 조회 시 given ReviewEntity의 값과 return Dto의 값이 동일하면 성공
  - 실패
    - 후기 단건 조회 실패 - 후기 없음
      reviewRepository.findById(anyLong()) -> optional empty 시 실패
    - 후기 단건 조회 실패 - 조회한 후기가 해당 모집글의 후기가 아님
      reviewRepository.existsByIdAndPostId(anyLong(), anyLong()) -> false 시 실패
 
- [X] API 테스트 
<!-- 테스트 방식 상세기술 권장 --> 
