### PR TITLE
feat : 평점 주기 기능 로직 수정

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/api/UserApi.java
+++ b/travel/src/main/java/com/zerobase/travel/api/UserApi.java
@@ -1,0 +1,20 @@
+package com.zerobase.travel.api;
+
+import com.zerobase.travel.api.UserApiRequestDto.UpdateUserRating;
+import com.zerobase.travel.common.response.ResponseMessage;
+import com.zerobase.travel.post.entity.UserClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserApi {
+
+    private final UserClient userFeignClient;
+
+    public ResponseMessage<Void> updateUserRating(long userId, double rating) {
+        return userFeignClient.getUserInfoByEmail(userId, new UpdateUserRating(rating));
+    }
+
+
+}

--- a/travel/src/main/java/com/zerobase/travel/api/UserApi.java
+++ b/travel/src/main/java/com/zerobase/travel/api/UserApi.java
@@ -13,7 +13,7 @@ public class UserApi {
     private final UserClient userFeignClient;
 
     public ResponseMessage<Void> updateUserRating(long userId, double rating) {
-        return userFeignClient.getUserInfoByEmail(userId, new UpdateUserRating(rating));
+        return userFeignClient.updateUserRating(userId, new UpdateUserRating(rating));
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/api/UserApiRequestDto.java
+++ b/travel/src/main/java/com/zerobase/travel/api/UserApiRequestDto.java
@@ -1,0 +1,21 @@
+package com.zerobase.travel.api;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class UserApiRequestDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @RequiredArgsConstructor
+    public static class UpdateUserRating {
+        private final Double avgRating;
+    }
+
+
+}

--- a/travel/src/main/java/com/zerobase/travel/controller/RatingController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/RatingController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,15 +21,12 @@ public class RatingController {
     
     @PostMapping("/posts/{postId}/rating")
     public ResponseEntity<ResponseMessage<Void>> registerRating(
+        @RequestHeader("X-User-Id") long userId,
         @PathVariable long postId,
         @RequestBody GiveRatingDto giveRatingDto
     ) {
 
-        //TODO 김용민 추후 스프링 시큐리티 개발시 authentic에서 가져오기
-        long userId = 1L;
-
         ratingService.giveRating(giveRatingDto, postId, userId);
-
         return ResponseEntity.ok(ResponseMessage.success());
     }
 

--- a/travel/src/main/java/com/zerobase/travel/post/entity/UserClient.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/UserClient.java
@@ -1,10 +1,13 @@
 package com.zerobase.travel.post.entity;
 
+import com.zerobase.travel.api.UserApiRequestDto.UpdateUserRating;
 import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 // User 서비스의 기본 URL을 설정합니다. Eureka 등을 사용하지 않는 경우, 직접 URL을 지정합니다.
 @FeignClient(name = "user-service", url = "${user-service.url}") // application.yml에 정의된 URL 사용
@@ -12,4 +15,11 @@ public interface UserClient {
 
     @GetMapping("/internal/api/v1/users/{userEmail}")
     ResponseMessage<UserInfoResponseDTO> getUserInfoByEmail(@PathVariable("userEmail") String userEmail);
+
+    @PutMapping("/internal/api/v1/users/{userId}/profile-rating")
+    ResponseMessage<Void> getUserInfoByEmail(
+        @PathVariable("userId") long userId,
+        @RequestBody UpdateUserRating request
+    );
+
 }

--- a/travel/src/main/java/com/zerobase/travel/post/entity/UserClient.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/UserClient.java
@@ -14,10 +14,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface UserClient {
 
     @GetMapping("/internal/api/v1/users/{userEmail}")
-    ResponseMessage<UserInfoResponseDTO> getUserInfoByEmail(@PathVariable("userEmail") String userEmail);
+    ResponseMessage<UserInfoResponseDTO> updateUserRating(@PathVariable("userEmail") String userEmail);
 
     @PutMapping("/internal/api/v1/users/{userId}/profile-rating")
-    ResponseMessage<Void> getUserInfoByEmail(
+    ResponseMessage<Void> updateUserRating(
         @PathVariable("userId") long userId,
         @RequestBody UpdateUserRating request
     );

--- a/travel/src/main/java/com/zerobase/travel/post/service/UserClientService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/UserClientService.java
@@ -17,7 +17,7 @@ public class UserClientService {
     private final UserClient userClient;
 
     public UserInfoResponseDTO getUserInfo(String userEmail) {
-        ResponseMessage<UserInfoResponseDTO> response = userClient.getUserInfoByEmail(userEmail);
+        ResponseMessage<UserInfoResponseDTO> response = userClient.updateUserRating(userEmail);
         if (response.getResult().equals(SUCCESS.toString())) {
             return response.getData();
         } else {

--- a/travel/src/main/java/com/zerobase/travel/repository/RatingRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/RatingRepository.java
@@ -2,8 +2,17 @@ package com.zerobase.travel.repository;
 
 import com.zerobase.travel.entity.RatingEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RatingRepository extends JpaRepository<RatingEntity, Long> {
 
     boolean existsByPostIdAndSenderUserIdAndReceiverUserId(long postId, long senderUserId, long receiverUserId);
+
+    @Query(
+        value = " select avg(rating.score) "
+            + " from RatingEntity rating"
+            + " where rating.receiverUserId = :userId "
+    )
+    Double getAvgReceiverRating(long userId);
 }

--- a/travel/src/main/java/com/zerobase/travel/service/RatingService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/RatingService.java
@@ -1,5 +1,6 @@
 package com.zerobase.travel.service;
 
+import com.zerobase.travel.api.UserApi;
 import com.zerobase.travel.dto.request.GiveRatingDto;
 import com.zerobase.travel.entity.RatingEntity;
 import com.zerobase.travel.exception.BizException;
@@ -7,6 +8,7 @@ import com.zerobase.travel.exception.errorcode.RatingErrorCode;
 import com.zerobase.travel.repository.RatingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +19,9 @@ public class RatingService {
     private final static double SCORE_UNIT = 0.5;
 
     private final RatingRepository ratingRepository;
+    private final UserApi userApi;
 
+    @Transactional
     public void giveRating(GiveRatingDto giveRatingDto, long postId, long senderUserId) {
 
         validationRegisterRating(postId, senderUserId, giveRatingDto.getReceiverId(), giveRatingDto.getScore());
@@ -32,8 +36,10 @@ public class RatingService {
 
         ratingRepository.save(rating);
 
-        //TODO 김용민 받은사람 프로필에 반영해주기
-        // 평점반영 api 필요
+        Double avgReceiverRating = ratingRepository.getAvgReceiverRating(giveRatingDto.getReceiverId());
+        double avrRating = Math.ceil(avgReceiverRating * 10) / 10.0;
+        userApi.updateUserRating(giveRatingDto.getReceiverId(), avrRating);
+
     }
 
     //TODO 김용민 validationRegisterRating 작성하기

--- a/travel/src/test/java/com/zerobase/travel/controller/RatingControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/controller/RatingControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(RatingController.class)
@@ -31,6 +33,7 @@ class RatingControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
+    @WithMockUser
     void registerRating() throws Exception {
 
         //given
@@ -44,6 +47,8 @@ class RatingControllerTest {
         //when
         //then
         mockMvc.perform(post("/api/v1/posts/{postId}/rating", postId)
+                .with(csrf())
+                .header("X-User-Id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(giveRatingDto)))
             .andExpect(status().isOk())

--- a/travel/src/test/java/com/zerobase/travel/service/RatingServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/RatingServiceTest.java
@@ -2,11 +2,14 @@ package com.zerobase.travel.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.zerobase.travel.api.UserApi;
+import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.dto.request.GiveRatingDto;
 import com.zerobase.travel.entity.RatingEntity;
 import com.zerobase.travel.exception.BizException;
@@ -26,6 +29,9 @@ class RatingServiceTest {
     @Mock
     private RatingRepository ratingRepository;
 
+    @Mock
+    private UserApi userApi;
+
     @InjectMocks
     private RatingService ratingService;
 
@@ -43,6 +49,11 @@ class RatingServiceTest {
             .build();
 
         ArgumentCaptor<RatingEntity> captor = ArgumentCaptor.forClass(RatingEntity.class);
+
+        given(userApi.updateUserRating(anyLong(), anyDouble()))
+            .willReturn(ResponseMessage.<Void>builder()
+                .result("SUCCSS")
+                .build());
 
         //when
         ratingService.giveRating(giveRatingDto, postId, senderUserId);


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
사용자에게 평점을 줄 시 평점을 받은 사용자의 profile의 평균 평점을 update 해준다.

## 🔑 PR에서 핵심적으로 변경된 사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존에는 user profile update를 하지 않고 평점 테이블에만 저장을함

**TO-BE**
user profile을 평균 평점으로 update를 해줌
- 평균 평점은 소숫점 한자리를 기준으로 올림처리함.

- 로직 수정이 되어 테스트 코드 수정

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 없음으로 표기  -->
- UserClient 부분에 updateUserRating 추가
- JPQL을 통한 평균 구하는 메소드 추가

## 📊 테스트
- [X] 테스트 코드
기존 success 테스트 로직에 userApi mock 처리하였음
    
- [X] API 테스트 
<!-- 테스트 방식 상세기술 권장 --> 

## ✏추가 사항
현재는 RatingService에 사용자 프로필 평점 update 부분을 넣어주었지만
Facade 패턴을 도입해 facade 클래스에
{
  ratingservice.giveRating(...);
  userApi.updateUserRating(...);
}

방식으로 작성하게된다면 메소드만으로 어떤 기능인지 빠르게 확인할 수 있고
테스트의 수정이 없었을 것으로 생각한다.