### PR TITLE
refactor : userId를 header를 통해 가져오도록 변경

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/controller/ReportingController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ReportingController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,15 +21,12 @@ public class ReportingController {
     
     @PostMapping("/posts/{postId}/reporting")
     public ResponseEntity<ResponseMessage<Void>> reportingUser(
+        @RequestHeader("X-User-Id") long userId,
         @PathVariable long postId,
         @RequestBody ReportingRequestDto.ReportUser request
     ) {
 
-        //TODO 김용민 추후 스프링 시큐리티 개발시 authentic에서 가져오기
-        long userId = 1L;
-
         reportingService.reportingUser(request, postId, userId);
-
         return ResponseEntity.ok(ResponseMessage.success());
     }
 

--- a/travel/src/main/java/com/zerobase/travel/controller/VoteController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/VoteController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,24 +23,18 @@ public class VoteController {
     
     @PostMapping("/posts/{postId}/voting-starts")
     public ResponseEntity<ResponseMessage<Void>> createVote(
+        @RequestHeader("X-User-Id") long userId,
         @PathVariable long postId
     ) {
-
-        //TODO 김용민 추후 스프링 시큐리티 개발시 authentic에서 가져오기
-        long userId = 1L;
         voteService.createVote(userId, postId);
-
         return ResponseEntity.ok(ResponseMessage.success());
     }
 
     @GetMapping("/posts/{postId}/voting-starts")
     public ResponseEntity<ResponseMessage<VoteResponseDto.VotingStart>> getVotingStart(
+        @RequestHeader("X-User-Id") long userId,
         @PathVariable long postId
     ) {
-
-        //TODO 김용민 추후 스프링 시큐리티 개발시 authentic에서 가져오기
-        long userId = 1L;
-
         return ResponseEntity.ok(ResponseMessage.success(
             voteService.getVotingStart(userId, postId)
         ));
@@ -47,27 +42,22 @@ public class VoteController {
 
     @PostMapping("/posts/{postId}/voting-starts/{votingStartsId}/votings")
     public ResponseEntity<ResponseMessage<Void>> voteVoting(
+        @RequestHeader("X-User-Id") long userId,
         @PathVariable long postId,
         @PathVariable long votingStartsId,
         @RequestBody VoteRequestDto.VoteVoting request
 
     ) {
-
-        //TODO 김용민 추후 스프링 시큐리티 개발시 authentic에서 가져오기
-        long userId = 1L;
         voteService.voteVoting(userId, postId, votingStartsId, request.getApproval());
-
         return ResponseEntity.ok(ResponseMessage.success());
     }
 
     @GetMapping("/posts/{postId}/voting-starts/{votingStartsId}/votings")
     public ResponseEntity<ResponseMessage<VoteResponseDto.GetVote>> getVote(
+        @RequestHeader("X-User-Id") long userId,
         @PathVariable long postId,
         @PathVariable long votingStartsId
     ) {
-
-        //TODO 김용민 추후 스프링 시큐리티 개발시 authentic에서 가져오기
-        long userId = 1L;
         return ResponseEntity.ok(ResponseMessage.success(
             voteService.getVote(userId, postId, votingStartsId)
         ));

--- a/travel/src/test/java/com/zerobase/travel/controller/ReportingControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/controller/ReportingControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ReportingController.class)
@@ -31,6 +33,7 @@ class ReportingControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
+    @WithMockUser
     void reportingUser() throws Exception {
 
         //given
@@ -43,6 +46,8 @@ class ReportingControllerTest {
         //when
         //then
         mockMvc.perform(post("/api/v1/posts/{postId}/reporting", postId)
+                .with(csrf())
+                .header("X-User-Id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(reportUser)))
             .andExpect(status().isOk())

--- a/travel/src/test/java/com/zerobase/travel/controller/VoteControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/controller/VoteControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -22,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(VoteController.class)
@@ -37,6 +39,7 @@ class VoteControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
+    @WithMockUser
     void createVote() throws Exception {
 
         //given
@@ -44,7 +47,9 @@ class VoteControllerTest {
 
         //when
         //then
-        mockMvc.perform(post("/api/v1/posts/{postId}/voting-starts", postId))
+        mockMvc.perform(post("/api/v1/posts/{postId}/voting-starts", postId)
+                .with(csrf())
+                .header("X-User-Id", "1"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result").value("SUCCESS"));
 
@@ -52,8 +57,8 @@ class VoteControllerTest {
 
     }
 
-    //TODO 김용민 votingStart 조회 테스트 작성하기
     @Test
+    @WithMockUser
     void getVotingStart() throws Exception {
 
         //given
@@ -70,7 +75,9 @@ class VoteControllerTest {
 
         //when
         //then
-        mockMvc.perform(get("/api/v1/posts/{postId}/voting-starts", postId))
+        mockMvc.perform(get("/api/v1/posts/{postId}/voting-starts", postId)
+                .with(csrf())
+                .header("X-User-Id", "1"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result").value("SUCCESS"))
             .andExpect(jsonPath("$.data.votingStartsId").value(1L))
@@ -83,6 +90,7 @@ class VoteControllerTest {
 
 
     @Test
+    @WithMockUser
     void voteVoting() throws Exception {
 
         //given
@@ -96,8 +104,9 @@ class VoteControllerTest {
         //when
         //then
         mockMvc.perform(
-                post("/api/v1/posts/{postId}/voting-starts/{votingStartsId}/votings", postId,
-                    votingStartsId)
+                post("/api/v1/posts/{postId}/voting-starts/{votingStartsId}/votings", postId, votingStartsId)
+                    .with(csrf())
+                    .header("X-User-Id", "1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(voteVoting)))
             .andExpect(status().isOk())
@@ -108,6 +117,7 @@ class VoteControllerTest {
     }
 
     @Test
+    @WithMockUser
     void getVote() throws Exception {
 
         //given
@@ -138,8 +148,9 @@ class VoteControllerTest {
 
         //when
         //then
-        mockMvc.perform(get("/api/v1/posts/{postId}/voting-starts/{votingStartsId}/votings", postId,
-                votingStartsId))
+        mockMvc.perform(get("/api/v1/posts/{postId}/voting-starts/{votingStartsId}/votings", postId, votingStartsId)
+                .with(csrf())
+                .header("X-User-Id", "1"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result").value("SUCCESS"))
             .andExpect(jsonPath("$.data.votings[0].votingId").value(1L))


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
임시로 userId를 고정시켜 놓았던 것을 header를 통해 userId를 받도록 변경

## 🔑 PR에서 핵심적으로 변경된 사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
메소드 내부에서 long userId = 1L; 로 고정되어있었음.

**TO-BE**
header를 통해 userId를 받아오도록 변경

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 없음으로 표기  -->
- header 방식으로 가져올수 있게 테스트 코드를 수정함
- spring security 적용으로인해 테스트가 fail나오는 상황을 csrf와 mockUser 설정으로 해결

## 📊 테스트
- [X] 테스트 코드

