### PR TITLE
refactor) Community 기능추가 ; UserId 검증, 페이징처리

### DIFF
--- a/pay/src/main/resources/application.yml
+++ b/pay/src/main/resources/application.yml
@@ -1,21 +1,21 @@
 server:
-  port: 8081
+  port: 8080
 
 spring:
   application:
-    name: travel
+    name: name
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/zerobase_travel
-    username: root
-    password: "!tkdghk6226"
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:travel_travel;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: password
 
   jpa:
     defer-datasource-initialization: true
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:
@@ -26,13 +26,6 @@ spring:
     multipart:
       maxFileSize: 10MB # 파일 하나의 최대 크기
       maxRequestSize: 30MB  # 한 번에 최대 업로드 가능 용량
-
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
 
 #eureka:
 #  client:

--- a/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
@@ -1,79 +1,79 @@
-package com.zerobase.travel.communities.controller;
+    package com.zerobase.travel.communities.controller;
 
-import com.zerobase.travel.communities.service.CommunityManagementService;
-import com.zerobase.travel.communities.type.RequestCreateCommunity;
-import com.zerobase.travel.communities.type.RequestPostCommunity;
-import com.zerobase.travel.communities.type.ResponseCommunityDto;
-import com.zerobase.travel.post.dto.response.PagedResponseDTO;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+    import com.zerobase.travel.communities.service.CommunityManagementService;
+    import com.zerobase.travel.communities.type.RequestCreateCommunity;
+    import com.zerobase.travel.communities.type.RequestPostCommunity;
+    import com.zerobase.travel.communities.type.ResponseCommunityDto;
+    import com.zerobase.travel.post.dto.response.PagedResponseDTO;
+    import jakarta.validation.Valid;
+    import jakarta.validation.constraints.Min;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.data.domain.Pageable;
+    import org.springframework.data.domain.Sort.Direction;
+    import org.springframework.data.web.PageableDefault;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.DeleteMapping;
+    import org.springframework.web.bind.annotation.GetMapping;
+    import org.springframework.web.bind.annotation.PathVariable;
+    import org.springframework.web.bind.annotation.PostMapping;
+    import org.springframework.web.bind.annotation.PutMapping;
+    import org.springframework.web.bind.annotation.RequestBody;
+    import org.springframework.web.bind.annotation.RequestHeader;
+    import org.springframework.web.bind.annotation.RequestMapping;
+    import org.springframework.web.bind.annotation.RestController;
 
-@RestController
-@RequestMapping(value = "/communities")
-@RequiredArgsConstructor
-public class CommunityController {
+    @RestController
+    @RequestMapping(value = "/communities")
+    @RequiredArgsConstructor
+    public class CommunityController {
 
-    private final CommunityManagementService communityManagementService;
+        private final CommunityManagementService communityManagementService;
 
 
-    // 새로운 커뮤니티 생성
-    @PostMapping
-    public ResponseEntity<ResponseCommunityDto> createCommunity(
-        @Valid @RequestBody
-        RequestCreateCommunity request, @RequestHeader("X-User-Id") String userId) {
+        // 새로운 커뮤니티 생성
+        @PostMapping
+        public ResponseEntity<ResponseCommunityDto> createCommunity(
+            @Valid @RequestBody
+            RequestCreateCommunity request, @RequestHeader("X-User-Id") String userId) {
 
-        return ResponseEntity.ok
-            (communityManagementService.createPost(request,userId));
+            return ResponseEntity.ok
+                (communityManagementService.createPost(request,userId));
+        }
+
+        // 커뮤니티 페이지 항상 최신순으로 조회
+        @GetMapping
+        public ResponseEntity<PagedResponseDTO<ResponseCommunityDto>> getCommunities(
+            @PageableDefault(size = 8, sort = "communityId", direction = Direction.DESC) Pageable pageable
+        ) {
+
+            return ResponseEntity.ok(communityManagementService.getPosts(pageable));
+        }
+
+        // 커뮤니티 단건 조회
+        @GetMapping(value = "/{communityId}")
+        public ResponseEntity<ResponseCommunityDto> getCommunity(
+            @Min(1) @PathVariable long communityId) {
+            return ResponseEntity.ok(
+                communityManagementService.getPost(communityId));
+
+        }
+
+        // 커뮤니티 삭제
+        @DeleteMapping(value = "/{communityId}")
+        public ResponseEntity<ResponseCommunityDto> deleteCommunity(
+            @Min(1) @PathVariable long communityId,@RequestHeader("X-User-Id") String userId) {
+            communityManagementService.deletePost(communityId,userId);
+
+            return ResponseEntity.ok().build();
+        }
+
+        // 커뮤니티 수정
+        @PutMapping(value = "/{communityId}")
+        public ResponseEntity<ResponseCommunityDto> updateCommunity(
+            @Valid @RequestBody RequestPostCommunity request,@RequestHeader("X-User-Id") String userId) {
+            return ResponseEntity.ok(
+                communityManagementService.updatePost(request,userId));
+        }
+
+
     }
-
-    // 커뮤니티 페이지 항상 최신순으로 조회
-    @GetMapping
-    public ResponseEntity<PagedResponseDTO<ResponseCommunityDto>> getCommunities(
-        @PageableDefault(size = 8, sort = "communityId", direction = Direction.DESC) Pageable pageable
-    ) {
-
-        return ResponseEntity.ok(communityManagementService.getPosts(pageable));
-    }
-
-    // 커뮤니티 단건 조회
-    @GetMapping(value = "/{communityId}")
-    public ResponseEntity<ResponseCommunityDto> getCommunity(
-        @Min(1) @PathVariable long communityId) {
-        return ResponseEntity.ok(
-            communityManagementService.getPost(communityId));
-
-    }
-
-    // 커뮤니티 삭제
-    @DeleteMapping(value = "/{communityId}")
-    public ResponseEntity<ResponseCommunityDto> deleteCommunity(
-        @Min(1) @PathVariable long communityId,@RequestHeader("X-User-Id") String userId) {
-        communityManagementService.deletePost(communityId,userId);
-
-        return ResponseEntity.ok().build();
-    }
-
-    // 커뮤니티 수정
-    @PutMapping(value = "/{communityId}")
-    public ResponseEntity<ResponseCommunityDto> updateCommunity(
-        @Valid @RequestBody RequestPostCommunity request,@RequestHeader("X-User-Id") String userId) {
-        return ResponseEntity.ok(
-            communityManagementService.updatePost(request,userId));
-    }
-
-
-}

--- a/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,10 +34,10 @@ public class CommunityController {
     @PostMapping
     public ResponseEntity<ResponseCommunityDto> createCommunity(
         @Valid @RequestBody
-        RequestCreateCommunity request) {
+        RequestCreateCommunity request, @RequestHeader("X-User-Id") String userId) {
 
         return ResponseEntity.ok
-            (communityManagementService.createPost(request));
+            (communityManagementService.createPost(request,userId));
     }
 
     // 커뮤니티 페이지 항상 최신순으로 조회
@@ -60,8 +61,8 @@ public class CommunityController {
     // 커뮤니티 삭제
     @DeleteMapping(value = "/{communityId}")
     public ResponseEntity<ResponseCommunityDto> deleteCommunity(
-        @Min(1) @PathVariable long communityId) {
-        communityManagementService.deletePost(communityId);
+        @Min(1) @PathVariable long communityId,@RequestHeader("X-User-Id") String userId) {
+        communityManagementService.deletePost(communityId,userId);
 
         return ResponseEntity.ok().build();
     }
@@ -69,9 +70,9 @@ public class CommunityController {
     // 커뮤니티 수정
     @PutMapping(value = "/{communityId}")
     public ResponseEntity<ResponseCommunityDto> updateCommunity(
-        @Valid @RequestBody RequestPostCommunity request) {
+        @Valid @RequestBody RequestPostCommunity request,@RequestHeader("X-User-Id") String userId) {
         return ResponseEntity.ok(
-            communityManagementService.updatePost(request));
+            communityManagementService.updatePost(request,userId));
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
@@ -4,11 +4,13 @@ import com.zerobase.travel.communities.service.CommunityManagementService;
 import com.zerobase.travel.communities.type.RequestCreateCommunity;
 import com.zerobase.travel.communities.type.RequestPostCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
+import com.zerobase.travel.post.dto.response.PagedResponseDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,8 +41,9 @@ public class CommunityController {
 
     // 커뮤니티 페이지 항상 최신순으로 조회
     @GetMapping
-    public ResponseEntity<Page<ResponseCommunityDto>> getCommunities(
-        Pageable pageable) {
+    public ResponseEntity<PagedResponseDTO<ResponseCommunityDto>> getCommunities(
+        @PageableDefault(size = 8, sort = "communityId", direction = Direction.DESC) Pageable pageable
+    ) {
 
         return ResponseEntity.ok(communityManagementService.getPosts(pageable));
     }
@@ -60,7 +63,7 @@ public class CommunityController {
         @Min(1) @PathVariable long communityId) {
         communityManagementService.deletePost(communityId);
 
-        return null;
+        return ResponseEntity.ok().build();
     }
 
     // 커뮤니티 수정

--- a/travel/src/main/java/com/zerobase/travel/communities/entity/CommunityEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/entity/CommunityEntity.java
@@ -33,7 +33,7 @@ public class CommunityEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long communityId;
     @Column(nullable = false)
-    private Long userId;
+    private String userId;
     @Enumerated(EnumType.STRING)
     private Continent continent;
     @Enumerated(EnumType.STRING)

--- a/travel/src/main/java/com/zerobase/travel/communities/entity/CommunityEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/entity/CommunityEntity.java
@@ -4,16 +4,21 @@ import com.zerobase.travel.typeCommon.Continent;
 import com.zerobase.travel.typeCommon.Country;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
@@ -21,6 +26,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class CommunityEntity {
 
     @Id
@@ -36,6 +42,10 @@ public class CommunityEntity {
     private String title;
     private String content;
 
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
 
 

--- a/travel/src/main/java/com/zerobase/travel/communities/repository/CommunityRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/repository/CommunityRepository.java
@@ -19,5 +19,7 @@ public interface CommunityRepository extends JpaRepository<CommunityEntity, Long
 
 
     Optional<CommunityEntity> findByCommunityId(long communityId);
+
+    Optional<CommunityEntity> findByUserId(String userId);
 }
 

--- a/travel/src/main/java/com/zerobase/travel/communities/service/CommunityManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/service/CommunityManagementService.java
@@ -5,6 +5,7 @@ import com.zerobase.travel.communities.type.CommunityFileDto;
 import com.zerobase.travel.communities.type.RequestCreateCommunity;
 import com.zerobase.travel.communities.type.RequestPostCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
+import com.zerobase.travel.post.dto.response.PagedResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,7 +36,8 @@ public class CommunityManagementService {
     }
 
     //다건 조회
-    public Page<ResponseCommunityDto> getPosts(Pageable pageable) {
+    public PagedResponseDTO<ResponseCommunityDto> getPosts(Pageable pageable) {
+
 
         Page<CommunityDto> communityDtos = communityService.getPosts(pageable);
 
@@ -43,8 +45,27 @@ public class CommunityManagementService {
             -> ResponseCommunityDto.fromEntity(e,
             communityFileService.getFiles(e.getCommunityId())));
 
-         return responseCommunityDtos;
+        return ConvertPageToPagedResponse(
+            responseCommunityDtos);
     }
+
+    private static PagedResponseDTO<ResponseCommunityDto> ConvertPageToPagedResponse(
+        Page<ResponseCommunityDto> responseCommunityDtos) {
+
+        // PagedResponseDTO로 변환
+        PagedResponseDTO<ResponseCommunityDto> pagedResponse
+            = PagedResponseDTO.<ResponseCommunityDto>builder()
+            .content(responseCommunityDtos.getContent())
+            .pageNumber(responseCommunityDtos.getNumber())
+            .pageSize(responseCommunityDtos.getSize())
+            .totalElements(responseCommunityDtos.getTotalElements())
+            .totalPages(responseCommunityDtos.getTotalPages())
+            .last(responseCommunityDtos.isLast())
+            .build();
+
+        return pagedResponse;
+    }
+
 
     // 단건조회
     public ResponseCommunityDto getPost(long communityId) {

--- a/travel/src/main/java/com/zerobase/travel/communities/service/CommunityManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/service/CommunityManagementService.java
@@ -23,11 +23,12 @@ public class CommunityManagementService {
 
     // 포스트 생성
     @Transactional
-    public ResponseCommunityDto createPost(RequestCreateCommunity request) {
+    public ResponseCommunityDto createPost(RequestCreateCommunity request,
+        String userId) {
 
         CommunityDto communityDto = communityService.createPost(
             request.getContinent(),request.getCountry(),request.getRegion(),
-            request.getTitle(),request.getContent());
+            request.getTitle(),request.getContent(),userId);
 
         List<CommunityFileDto> communityFileDtos
             = communityFileService.saveFiles(communityDto.getCommunityId(),request.getFiles());
@@ -79,19 +80,21 @@ public class CommunityManagementService {
 
     //단건 삭제
     @Transactional
-    public void deletePost(long communityId) {
-        communityService.deletePost(communityId);
+    public void deletePost(long communityId, String userId) {
+        communityService.deletePost(communityId,userId);
         communityFileService.deleteAllByCommunityId(communityId);
 
 
     }
 
     @Transactional
-    public ResponseCommunityDto updatePost( RequestPostCommunity request) {
+    public ResponseCommunityDto updatePost( RequestPostCommunity request,
+        String userId) {
+
 
         CommunityDto communityDto = communityService.updatePost(request.getCommunityId(),
             request.getContinent(),request.getCountry(),request.getRegion(),
-            request.getTitle(),request.getContent());
+            request.getTitle(),request.getContent(),userId);
 
         communityFileService.deleteAllByCommunityId(request.getCommunityId());
 

--- a/travel/src/main/java/com/zerobase/travel/communities/service/CommunityService.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/service/CommunityService.java
@@ -7,6 +7,7 @@ import com.zerobase.travel.communities.type.CustomException;
 import com.zerobase.travel.communities.type.ErrorCode;
 import com.zerobase.travel.typeCommon.Continent;
 import com.zerobase.travel.typeCommon.Country;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,13 +22,13 @@ public class CommunityService {
 
     public CommunityDto createPost(Continent continent,
         Country country, String region,
-        String title, String content) {
+        String title, String content, String userId) {
 
         CommunityEntity entity = communityRepository.
             save(
                 CommunityEntity
                     .builder()
-                    .userId(123L)
+                    .userId(userId)
                     .continent(continent)
                     .country(country)
                     .region(region)
@@ -61,17 +62,24 @@ public class CommunityService {
 
 
 
-    public void deletePost(long communityId) {
+    public void deletePost(long communityId, String userId) {
+
+        communityRepository.findByUserId(userId).orElseThrow(()
+            -> new CustomException(ErrorCode.USER_UNAUTHORIZED_REQUEST));
+
         communityRepository.deleteByCommunityId(communityId);
     }
 
     public CommunityDto updatePost(long communityId, Continent continent,
         Country country,
-        String region, String title, String content) {
+        String region, String title, String content, String userId) {
 
         CommunityEntity communityEntity = communityRepository.findByCommunityId(
             communityId).orElseThrow(()
             -> new CustomException(ErrorCode.COMMUNITY_NON_EXISTENT));
+
+        if(!Objects.equals(communityEntity.getUserId(), userId))
+            throw new CustomException(ErrorCode.USER_UNAUTHORIZED_REQUEST);
 
         communityEntity.setContinent(continent);
         communityEntity.setCountry(country);

--- a/travel/src/main/java/com/zerobase/travel/communities/service/CommunityService.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/service/CommunityService.java
@@ -48,7 +48,7 @@ public class CommunityService {
         return CommunityDto.fromEntity(communityEntity);
     }
 
-    // 포스트 다건 조회
+    // 포스트 8건 조회
     public Page<CommunityDto> getPosts(Pageable pageable) {
         Page<CommunityEntity> communityEntities = communityRepository.findAll(
             pageable);

--- a/travel/src/main/java/com/zerobase/travel/communities/type/CommunityDto.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/CommunityDto.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Builder
 public class CommunityDto {
 
-    long communityId;
+    Long communityId;
     String userId;
     Continent continent;
     Country country;

--- a/travel/src/main/java/com/zerobase/travel/communities/type/CommunityDto.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/CommunityDto.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class CommunityDto {
 
     long communityId;
-    long userId;
+    String userId;
     Continent continent;
     Country country;
     String region;

--- a/travel/src/main/java/com/zerobase/travel/communities/type/ErrorCode.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/ErrorCode.java
@@ -1,5 +1,5 @@
 package com.zerobase.travel.communities.type;
 
 public enum ErrorCode {
-    PARTICIPATION_NOT_FOUND, COMMUNITY_NON_EXISTENT
+    PARTICIPATION_NOT_FOUND, USER_UNAUTHORIZED_REQUEST, COMMUNITY_NON_EXISTENT
 }

--- a/travel/src/main/java/com/zerobase/travel/communities/type/RequestCreateCommunity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/RequestCreateCommunity.java
@@ -5,11 +5,17 @@ import com.zerobase.travel.typeCommon.Country;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class RequestCreateCommunity {
 
     @NotNull

--- a/travel/src/main/java/com/zerobase/travel/communities/type/RequestPostCommunity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/RequestPostCommunity.java
@@ -6,11 +6,17 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class RequestPostCommunity {
 
 

--- a/travel/src/main/java/com/zerobase/travel/communities/type/ResponseCommunityDto.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/ResponseCommunityDto.java
@@ -17,7 +17,7 @@ import lombok.Setter;
 public class ResponseCommunityDto {
 
     long communityId;
-    long userId;
+    String userId;
     Continent continent;
     Country country;
     String region;

--- a/travel/src/main/java/com/zerobase/travel/config/JpaAuditingConfig.java
+++ b/travel/src/main/java/com/zerobase/travel/config/JpaAuditingConfig.java
@@ -1,0 +1,11 @@
+package com.zerobase.travel.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/travel/src/main/java/com/zerobase/travel/post/dto/response/PagedResponseDTO.java
+++ b/travel/src/main/java/com/zerobase/travel/post/dto/response/PagedResponseDTO.java
@@ -1,11 +1,16 @@
 package com.zerobase.travel.post.dto.response;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageImpl;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PagedResponseDTO<T> {
     private List<T> content;
     private int pageNumber;
@@ -13,4 +18,6 @@ public class PagedResponseDTO<T> {
     private long totalElements;
     private int totalPages;
     private boolean last;
+
+
 }

--- a/travel/src/main/resources-dev/application-dev.yml
+++ b/travel/src/main/resources-dev/application-dev.yml
@@ -6,14 +6,14 @@ spring:
     name: travel
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://travel_mysql:3306/travel_travel?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
-    username: root
-    password: 1q2w3e4r@@
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:travel_travel;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: password
 
   jpa:
     defer-datasource-initialization: true
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: update
     open-in-view: false

--- a/travel/src/test/java/com/zerobase/travel/communities/controller/CommunityControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/controller/CommunityControllerTest.java
@@ -1,0 +1,222 @@
+package com.zerobase.travel.communities.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.travel.communities.service.CommunityManagementService;
+import com.zerobase.travel.communities.type.RequestCreateCommunity;
+import com.zerobase.travel.communities.type.RequestPostCommunity;
+import com.zerobase.travel.communities.type.ResponseCommunityDto;
+import com.zerobase.travel.post.dto.response.PagedResponseDTO;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.http.MediaType;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(controllers = CommunityController.class)
+class CommunityControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CommunityManagementService communityManagementService;
+
+    @InjectMocks
+    private CommunityController communityController;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String SAMPLE_USER_ID = "user123";
+    private ResponseCommunityDto sampleCommunityResponse;
+
+
+    @BeforeEach
+    void setUp() {
+
+        // given mock return value
+        sampleCommunityResponse = ResponseCommunityDto.builder()
+            .communityId(1L)
+            .userId(SAMPLE_USER_ID)
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Seoul")
+            .title("Sample Community")
+            .content("Sample content")
+            .files(Collections.emptyList())
+            .build();
+    }
+
+
+    @Test
+    @WithMockUser
+    void createCommunity() throws Exception {
+
+        // given request
+
+        List<String> files = List.of("file1", "file2");
+
+        RequestCreateCommunity request = RequestCreateCommunity.builder()
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Seoul")
+            .title("Sample Title")
+            .content("Sample Content")
+            .files(files)
+            .build();
+
+
+        //when
+
+        when(communityManagementService.createPost(any(RequestCreateCommunity.class),anyString()))
+            .thenReturn(sampleCommunityResponse);
+
+
+        mockMvc.perform(
+            post("/communities")
+                .header(USER_ID_HEADER, SAMPLE_USER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.communityId").value(1))
+            .andExpect(jsonPath("$.userId").value(SAMPLE_USER_ID))
+            .andExpect(jsonPath("$.title").value("Sample Community"))
+            .andExpect(jsonPath("$.content").value("Sample content"));
+    }
+
+    @Test
+    @WithMockUser
+    void getCommunities() throws Exception {
+        // Given a pageable request
+        Pageable pageable = PageRequest.of(0, 8, Sort.by(Sort.Direction.DESC, "communityId"));
+
+        // Given a sample paged response from the service
+        PagedResponseDTO<ResponseCommunityDto> pagedResponse = PagedResponseDTO.<ResponseCommunityDto>builder()
+            .content(List.of(sampleCommunityResponse))
+            .pageNumber(pageable.getPageNumber())
+            .pageSize(pageable.getPageSize())
+            .totalElements(1)
+            .totalPages(1)
+            .last(true)
+            .build();
+
+        // Mock the service response
+        when(communityManagementService.getPosts(any(Pageable.class))).thenReturn(pagedResponse);
+
+        // Perform the GET request with pagination parameters
+        mockMvc.perform(get("/communities")
+                .param("page", "0")
+                .param("size", "8")
+                .param("sort", "communityId,desc")
+                .with(csrf())) // Add CSRF token
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].communityId").value(1))
+            .andExpect(jsonPath("$.content[0].userId").value(SAMPLE_USER_ID))
+            .andExpect(jsonPath("$.content[0].title").value("Sample Community"))
+            .andExpect(jsonPath("$.content[0].content").value("Sample content"))
+            .andExpect(jsonPath("$.pageNumber").value(0))
+            .andExpect(jsonPath("$.pageSize").value(8))
+            .andExpect(jsonPath("$.totalElements").value(1))
+            .andExpect(jsonPath("$.totalPages").value(1))
+            .andExpect(jsonPath("$.last").value(true));
+
+        // Verify that the service method was called with the correct pageable
+        verify(communityManagementService, times(1)).getPosts(pageable);
+    }
+
+
+    @Test
+    @WithMockUser
+    void deleteCommunity() throws Exception {
+        // Given
+        long communityId = 1L;
+
+        // Mock the behavior of the service
+        doNothing().when(communityManagementService).deletePost(eq(communityId), eq(SAMPLE_USER_ID));
+
+        // Perform the delete request
+        mockMvc.perform(
+                delete("/communities/{communityId}", communityId)
+                    .header(USER_ID_HEADER, SAMPLE_USER_ID)
+                    .with(csrf()) // Add CSRF token for security
+            )
+            .andExpect(status().isOk()); // Expect 200 OK status
+
+        // Verify that the service method was called with correct parameters
+        verify(communityManagementService, times(1)).deletePost(communityId, SAMPLE_USER_ID);
+    }
+
+
+
+    @Test
+    @WithMockUser
+    void updateCommunity() throws Exception {
+        // Given an update request
+        RequestPostCommunity request = RequestPostCommunity.builder()
+            .communityId(1L)
+            .title("Updated Title")
+            .content("Updated Content")
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Busan")
+            .build();
+
+        // Mocking the service's response to return a sample community response
+        given(communityManagementService.updatePost(any(RequestPostCommunity.class), anyString()))
+            .willReturn(sampleCommunityResponse);
+
+        // Perform the PUT request
+        mockMvc.perform(
+            put("/communities/{communityId}", 1L)
+                .header(USER_ID_HEADER, SAMPLE_USER_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))  // Add CSRF token for PUT request
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.communityId").value(1L))
+            .andExpect(jsonPath("$.userId").value(SAMPLE_USER_ID))
+            .andExpect(jsonPath("$.title").value("Sample Community"))
+            .andExpect(jsonPath("$.content").value("Sample content"));
+
+        // Verify that the service method was called with the correct parameters
+        verify(communityManagementService, times(1)).updatePost(any(RequestPostCommunity.class), eq(SAMPLE_USER_ID));
+    }
+
+}

--- a/travel/src/test/java/com/zerobase/travel/communities/service/CommunityFileServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/service/CommunityFileServiceTest.java
@@ -1,0 +1,97 @@
+package com.zerobase.travel.communities.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.travel.communities.entity.CommunityEntity;
+import com.zerobase.travel.communities.entity.CommunityFileEntity;
+import com.zerobase.travel.communities.repository.CommunityFileRepository;
+import com.zerobase.travel.communities.type.CommunityFileDto;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityFileServiceTest {
+
+    @Mock
+    private CommunityFileRepository communityFileRepository;
+
+    @InjectMocks
+    private CommunityFileService communityFileService;
+
+    @Test
+    void getFiles() {
+        // Given input
+        Long communityId = 1L;
+
+        // Given mock return
+        List<CommunityFileEntity> mockFileEntities = List.of(
+            CommunityFileEntity.builder().communityFileId(1L).fileName("file1.jpg")
+                .communityEntity(CommunityEntity.builder().communityId(communityId).build())
+                .build(),
+            CommunityFileEntity.builder().communityFileId(2L).fileName("file2.jpg")
+                .communityEntity(CommunityEntity.builder().communityId(communityId).build())
+                .build()
+        );
+
+        given(communityFileRepository.findAllByCommunityEntity_CommunityId(communityId)).willReturn(mockFileEntities);
+
+        // When
+        List<CommunityFileDto> result = communityFileService.getFiles(communityId);
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getFileName()).isEqualTo("file1.jpg");
+        assertThat(result.get(1).getFileName()).isEqualTo("file2.jpg");
+
+        verify(communityFileRepository, times(1)).findAllByCommunityEntity_CommunityId(communityId);
+    }
+
+    @Test
+    void saveFiles() {
+        // Given
+        Long communityId = 1L;
+        List<String> fileNames = List.of("file1.jpg", "file2.jpg");
+
+        // Mock entities created during save
+        List<CommunityFileEntity> mockFileEntities = fileNames.stream()
+            .map(name -> CommunityFileEntity.builder()
+                .fileName(name)
+                .communityEntity(CommunityEntity.builder().communityId(communityId).build())
+                .build())
+            .toList();
+
+        given(communityFileRepository.saveAll(any())).willReturn(mockFileEntities);
+
+        // When
+        List<CommunityFileDto> result = communityFileService.saveFiles(communityId, fileNames);
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getCommunityId()).isEqualTo(communityId);
+        assertThat(result.get(0).getFileName()).isEqualTo("file1.jpg");
+        assertThat(result.get(1).getCommunityId()).isEqualTo(communityId);
+        assertThat(result.get(1).getFileName()).isEqualTo("file2.jpg");
+
+        verify(communityFileRepository, times(1)).saveAll(any());
+    }
+
+    @Test
+    void deleteAllByCommunityId() {
+        // Given
+        long communityId = 1L;
+
+        // When
+        communityFileService.deleteAllByCommunityId(communityId);
+
+        // Then
+        verify(communityFileRepository, times(1)).deleteAllByCommunityEntity_CommunityId(communityId);
+    }
+}

--- a/travel/src/test/java/com/zerobase/travel/communities/service/CommunityManagementServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/service/CommunityManagementServiceTest.java
@@ -1,0 +1,187 @@
+package com.zerobase.travel.communities.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.travel.communities.type.CommunityDto;
+import com.zerobase.travel.communities.type.CommunityFileDto;
+import com.zerobase.travel.communities.type.RequestCreateCommunity;
+import com.zerobase.travel.communities.type.RequestPostCommunity;
+import com.zerobase.travel.communities.type.ResponseCommunityDto;
+import com.zerobase.travel.post.dto.response.PagedResponseDTO;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityManagementServiceTest {
+
+    @Mock
+    private CommunityService communityService;
+
+    @Mock
+    private CommunityFileService communityFileService;
+
+    @InjectMocks
+    private CommunityManagementService communityManagementService;
+
+    private CommunityDto sampleCommunityDto;
+    private List<CommunityFileDto> sampleFiles;
+    private RequestCreateCommunity createRequest;
+
+    @BeforeEach
+    void setUp() {
+        sampleCommunityDto = CommunityDto.builder()
+            .communityId(1L)
+            .userId("user1")
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Busan")
+            .title("Sample Title")
+            .content("Sample Content")
+            .build();
+
+        sampleFiles = List.of(new CommunityFileDto(1L, "file1.jpg"),
+            new CommunityFileDto(2L, "file2.jpg"));
+
+        createRequest = RequestCreateCommunity.builder()
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Busan")
+            .title("Sample Title")
+            .content("Sample Content")
+            .files(List.of("file1.jpg", "file2.jpg"))
+            .build();
+    }
+
+    @Test
+    void createPost() {
+        // Given
+        given(communityService.createPost(any(), any(), any(), any(), any(), any())).willReturn(sampleCommunityDto);
+        given(communityFileService.saveFiles(anyLong(), any())).willReturn(sampleFiles);
+
+        // When
+        ResponseCommunityDto response = communityManagementService.createPost(createRequest, "user1");
+
+        // Then
+        assertThat(response.getCommunityId()).isEqualTo(1L);
+        assertThat(response.getTitle()).isEqualTo("Sample Title");
+        assertThat(response.getFiles()).hasSize(2);
+
+        verify(communityService, times(1)).createPost(any(), any(), any(), any(), any(), eq("user1"));
+        verify(communityFileService, times(1)).saveFiles(anyLong(), any());
+    }
+
+    @Test
+    void getPosts() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<CommunityDto> communityPage = new PageImpl<>(List.of(sampleCommunityDto), pageable, 1);
+        given(communityService.getPosts(pageable)).willReturn(communityPage);
+        given(communityFileService.getFiles(anyLong())).willReturn(sampleFiles);
+
+        // When
+        PagedResponseDTO<ResponseCommunityDto> response = communityManagementService.getPosts(pageable);
+
+        // Then
+        assertThat(response.getContent()).hasSize(1);
+        assertThat(response.getContent().get(0).getTitle()).isEqualTo("Sample Title");
+        assertThat(response.getContent().get(0).getFiles()).hasSize(2);
+
+        verify(communityService, times(1)).getPosts(pageable);
+        verify(communityFileService, times(1)).getFiles(anyLong());
+    }
+
+    @Test
+    void getPost() {
+        // Given
+        long communityId = 1L;
+        given(communityService.getPost(communityId)).willReturn(sampleCommunityDto);
+        given(communityFileService.getFiles(communityId)).willReturn(sampleFiles);
+
+        // When
+        ResponseCommunityDto response = communityManagementService.getPost(communityId);
+
+        // Then
+        assertThat(response.getCommunityId()).isEqualTo(1L);
+        assertThat(response.getTitle()).isEqualTo("Sample Title");
+        assertThat(response.getFiles()).hasSize(2);
+
+        verify(communityService, times(1)).getPost(communityId);
+        verify(communityFileService, times(1)).getFiles(communityId);
+    }
+
+    @Test
+    void deletePost() {
+        // Given
+        long communityId = 1L;
+        String userId = "user1";
+
+        // When
+        communityManagementService.deletePost(communityId, userId);
+
+        // Then
+        verify(communityService, times(1)).deletePost(communityId, userId);
+        verify(communityFileService, times(1)).deleteAllByCommunityId(communityId);
+    }
+
+    @Test
+    void updatePost() {
+        // Given
+        RequestPostCommunity request = RequestPostCommunity.builder()
+            .communityId(1L)
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Busan")
+            .title("Updated Title")
+            .content("Updated Content")
+            .files(List.of("updated_file1.jpg", "updated_file2.jpg"))
+            .build();
+
+        CommunityDto updatedCommunityDto = CommunityDto.builder()
+            .communityId(1L)
+            .userId("user1")
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Busan")
+            .title("Updated Title")
+            .content("Updated Content")
+            .build();
+
+        List<CommunityFileDto> updatedFiles = List.of(
+            new CommunityFileDto(1L, "updated_file1.jpg"),
+            new CommunityFileDto(2L, "updated_file2.jpg")
+        );
+
+        given(communityService.updatePost(anyLong(), any(), any(), any(), any(), any(), any()))
+            .willReturn(updatedCommunityDto);
+        given(communityFileService.saveFiles(anyLong(), any())).willReturn(updatedFiles);
+
+        // When
+        ResponseCommunityDto response = communityManagementService.updatePost(request, "user1");
+
+        // Then
+        assertThat(response.getTitle()).isEqualTo("Updated Title");
+        assertThat(response.getContent()).isEqualTo("Updated Content");
+        assertThat(response.getFiles()).hasSize(2);
+
+        verify(communityService, times(1)).updatePost(anyLong(), any(), any(), any(), any(), any(), eq("user1"));
+        verify(communityFileService, times(1)).deleteAllByCommunityId(anyLong());
+        verify(communityFileService, times(1)).saveFiles(anyLong(), any());
+    }
+}

--- a/travel/src/test/java/com/zerobase/travel/communities/service/CommunityServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/service/CommunityServiceTest.java
@@ -1,0 +1,213 @@
+package com.zerobase.travel.communities.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.zerobase.travel.communities.entity.CommunityEntity;
+import com.zerobase.travel.communities.repository.CommunityRepository;
+import com.zerobase.travel.communities.service.CommunityService;
+import com.zerobase.travel.communities.type.CommunityDto;
+import com.zerobase.travel.communities.type.CustomException;
+import com.zerobase.travel.communities.type.ErrorCode;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityServiceTest {
+
+    @Mock
+    private CommunityRepository communityRepository;
+
+    @InjectMocks
+    private CommunityService communityService;
+
+    @Test
+    void createPost() {
+        // Given input
+        String userId = "user1";
+        CommunityEntity entity = CommunityEntity.builder()
+            .userId(userId)
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Busan")
+            .title("Sample Title")
+            .content("Sample Content")
+            .build();
+
+        // Mock return for any CommunityEntity
+        given(communityRepository.save(any(CommunityEntity.class))).willReturn(entity);
+
+        // When
+        CommunityDto result = communityService.createPost(
+            Continent.ASIA, Country.KR, "Busan", "Sample Title", "Sample Content", userId);
+
+        // Then
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getContinent()).isEqualTo(Continent.ASIA);
+        assertThat(result.getCountry()).isEqualTo(Country.KR);
+        assertThat(result.getRegion()).isEqualTo("Busan");
+        assertThat(result.getTitle()).isEqualTo("Sample Title");
+        assertThat(result.getContent()).isEqualTo("Sample Content");
+
+        // Verify that the repository's save method was called once with any CommunityEntity
+        verify(communityRepository, times(1)).save(any(CommunityEntity.class));
+    }
+
+    @Test
+    void getPost() {
+        // Given
+        Long communityId = 1L;
+        CommunityEntity entity = CommunityEntity.builder()
+            .communityId(communityId)
+            .title("Sample Title")
+            .build();
+
+        given(communityRepository.findByCommunityId(communityId)).willReturn(Optional.of(entity));
+
+        // When
+        CommunityDto result = communityService.getPost(communityId);
+
+        // Then
+        assertThat(result.getCommunityId()).isEqualTo(communityId);
+        assertThat(result.getTitle()).isEqualTo("Sample Title");
+        verify(communityRepository, times(1)).findByCommunityId(communityId);
+    }
+
+    @Test
+    void getPost_nonExistent() {
+        // Given
+        Long communityId = 1L;
+        given(communityRepository.findByCommunityId(communityId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> communityService.getPost(communityId))
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.COMMUNITY_NON_EXISTENT);
+
+        verify(communityRepository, times(1)).findByCommunityId(communityId);
+    }
+
+    @Test
+    void getPosts() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 8);
+        List<CommunityEntity> entities = List.of(
+            CommunityEntity.builder().communityId(1L).title("Sample 1").build(),
+            CommunityEntity.builder().communityId(2L).title("Sample 2").build()
+        );
+        Page<CommunityEntity> page = new PageImpl<>(entities, pageable, entities.size());
+        given(communityRepository.findAll(pageable)).willReturn(page);
+
+        // When
+        Page<CommunityDto> result = communityService.getPosts(pageable);
+
+        // Then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("Sample 1");
+        assertThat(result.getContent().get(1).getTitle()).isEqualTo("Sample 2");
+        verify(communityRepository, times(1)).findAll(pageable);
+    }
+
+    @Test
+    void deletePost() {
+        // Given
+        long communityId = 1L;
+        String userId = "user1";
+        CommunityEntity entity = CommunityEntity.builder().communityId(communityId).userId(userId).build();
+        given(communityRepository.findByUserId(userId)).willReturn(Optional.of(entity));
+
+        // When
+        communityService.deletePost(communityId, userId);
+
+        // Then
+        verify(communityRepository, times(1)).deleteByCommunityId(communityId);
+    }
+
+    @Test
+    void deletePost_Unauthorized() {
+        // Given
+        long communityId = 1L;
+        String userId = "unauthorizedUser";
+        given(communityRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> communityService.deletePost(communityId, userId))
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.USER_UNAUTHORIZED_REQUEST);
+
+        verify(communityRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void updatePost() {
+        // Given
+        long communityId = 1L;
+        String userId = "user1";
+
+        CommunityEntity entity = CommunityEntity.builder()
+            .communityId(communityId)
+            .userId(userId)
+            .continent(Continent.ASIA)
+            .country(Country.KR)
+            .region("Seoul")
+            .title("Old Title")
+            .content("Old Content")
+            .build();
+
+        // Mock the find and save methods of the repository
+        given(communityRepository.findByCommunityId(communityId)).willReturn(Optional.of(entity));
+        given(communityRepository.save(any(CommunityEntity.class))).willReturn(entity);
+
+        // When
+        CommunityDto updatedDto = communityService.updatePost(
+            communityId, Continent.ASIA, Country.KR, "Busan", "Updated Title", "Updated Content", userId);
+
+        // Then
+        assertThat(updatedDto.getTitle()).isEqualTo("Updated Title");
+        assertThat(updatedDto.getContent()).isEqualTo("Updated Content");
+        assertThat(updatedDto.getRegion()).isEqualTo("Busan");
+        assertThat(updatedDto.getContinent()).isEqualTo(Continent.ASIA);
+        assertThat(updatedDto.getCountry()).isEqualTo(Country.KR);
+
+        // Verify that find and save were called exactly once
+        verify(communityRepository, times(1)).findByCommunityId(communityId);
+        verify(communityRepository, times(1)).save(any(CommunityEntity.class));
+    }
+
+    @Test
+    void updatePost_Unauthorized() {
+        // Given
+        long communityId = 1L;
+        String userId = "unauthorizedUser";
+        CommunityEntity entity = CommunityEntity.builder().communityId(communityId).userId("differentUser").build();
+
+        given(communityRepository.findByCommunityId(communityId)).willReturn(Optional.of(entity));
+
+        // When & Then
+        assertThatThrownBy(() -> communityService.updatePost(
+            communityId, Continent.ASIA, Country.KR, "Busan", "Updated Title", "Updated Content", userId))
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.USER_UNAUTHORIZED_REQUEST);
+
+        verify(communityRepository, times(1)).findByCommunityId(communityId);
+    }
+}


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
1. Community 기능에서 UserId 검증기능 추가
-> request Header에서 UserId를 확인하고, Service에서 create, delete, update 수행시 게시글의 userId와 요청자의 userId 동일여부확인
2. Community 게시글 페이징처리 
3. Community 기능 testCode 작성

## 📊 테스트
- [ x] 테스트 코드
- [ x] API 테스트 
