### PR TITLE
사용자 MBTI 수정시, travel 모듈쪽 해당 작성자의 모든 여행 게시물 MBTI 내용도 이벤트 발생시 수정.

### DIFF
--- a/travel/build.gradle
+++ b/travel/build.gradle
@@ -46,11 +46,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.security:spring-security-test'
 
     // Hibernate Spatial, Point
     implementation 'org.hibernate:hibernate-spatial:6.6.1.Final'
     implementation 'org.locationtech.jts:jts-core:1.18.2'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/travel/src/main/java/com/zerobase/travel/post/config/KafkaConsumerConfig.java
+++ b/travel/src/main/java/com/zerobase/travel/post/config/KafkaConsumerConfig.java
@@ -1,0 +1,69 @@
+package com.zerobase.travel.post.config;
+
+import com.zerobase.travel.post.kafka.UserMbtiChangedEvent;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.mapping.DefaultJackson2JavaTypeMapper;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+
+    @Bean
+    public ConsumerFactory<String, UserMbtiChangedEvent> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        // Kafka 브로커 주소
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // 그룹 ID 설정
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "travel-service-group");
+
+        // Key와 Value Deserializer 인스턴스 생성
+        StringDeserializer keyDeserializer = new StringDeserializer();
+
+        // 실제 역직렬화를 수행할 Deserializer 지정
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+
+        JsonDeserializer<UserMbtiChangedEvent> valueDeserializer = new JsonDeserializer<>(
+            UserMbtiChangedEvent.class);
+        valueDeserializer.setTypeMapper(customTypeMapper());
+        valueDeserializer.addTrustedPackages("*");
+
+        return new DefaultKafkaConsumerFactory<>(props, keyDeserializer, valueDeserializer);
+    }
+
+    private DefaultJackson2JavaTypeMapper customTypeMapper() {
+        DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
+
+        // 클래스 아이디에 대한 매핑 설정
+        Map<String, Class<?>> idClassMapping = new HashMap<>();
+        idClassMapping.put("com.zerobase.user.kafka.UserMbtiChangedEvent", UserMbtiChangedEvent.class);
+
+        typeMapper.setIdClassMapping(idClassMapping);
+        typeMapper.setTypePrecedence(DefaultJackson2JavaTypeMapper.TypePrecedence.TYPE_ID);
+
+        return typeMapper;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, UserMbtiChangedEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, UserMbtiChangedEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/travel/src/main/java/com/zerobase/travel/post/entity/PostEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/PostEntity.java
@@ -44,6 +44,7 @@ public class PostEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @Enumerated(EnumType.STRING)
     private MBTI mbti;
 
     private String title;

--- a/travel/src/main/java/com/zerobase/travel/post/kafka/UserMbtiChangedEvent.java
+++ b/travel/src/main/java/com/zerobase/travel/post/kafka/UserMbtiChangedEvent.java
@@ -1,0 +1,13 @@
+package com.zerobase.travel.post.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserMbtiChangedEvent {
+    private Long userId;
+    private String newMbti;
+}

--- a/travel/src/main/java/com/zerobase/travel/post/repository/PostRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/post/repository/PostRepository.java
@@ -1,12 +1,20 @@
 package com.zerobase.travel.post.repository;
 
 import com.zerobase.travel.post.entity.PostEntity;
+import com.zerobase.travel.post.type.MBTI;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long>, JpaSpecificationExecutor<PostEntity> {
 
     boolean existsByPostIdAndUserId(long postId, long organizerUserId);
+
+    @Modifying
+    @Query("UPDATE PostEntity p SET p.mbti = :mbti WHERE p.userId = :userId")
+    void updateMbtiByUserId(@Param("mbti") MBTI mbti, @Param("userId") Long userId);
 }

--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -336,7 +336,6 @@ public class PostService {
             .limitMaxAge(existingPost.getLimitMaxAge())
             .limitSex(existingPost.getLimitSex().name())
             .limitSmoke(existingPost.getLimitSmoke().name())
-            .preferenceType(existingPost.getPreferenceType())
             .deadline(existingPost.getDeadline())
             .days(existingPost.getDays().stream().map(dayEntity -> DayDTO.builder()
                 .dayDetails(
@@ -353,5 +352,18 @@ public class PostService {
                         .build()).collect(Collectors.toList()))
                 .build()).collect(Collectors.toList()))
             .build();
+    }
+
+    @Transactional
+    public void updatePostsMbti(Long userId, String newMbti) {
+        MBTI mbtiEnum;
+        try {
+            mbtiEnum = MBTI.valueOf(newMbti.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            // 예외 처리
+            return;
+        }
+
+        postRepository.updateMbtiByUserId(mbtiEnum, userId);
     }
 }

--- a/travel/src/main/java/com/zerobase/travel/post/service/UserMbtiChangedEventListener.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/UserMbtiChangedEventListener.java
@@ -1,0 +1,22 @@
+package com.zerobase.travel.post.service;
+
+import com.zerobase.travel.post.kafka.UserMbtiChangedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserMbtiChangedEventListener {
+
+    private final PostService postService;
+
+    @KafkaListener(topics = "${app.kafka.topics.user-mbti-changed}", groupId = "travel-service-group")
+    public void handleUserMbtiChangedEvent(UserMbtiChangedEvent event) {
+        Long userId = event.getUserId();
+        String newMbti = event.getNewMbti();
+
+        // 게시글의 MBTI 업데이트
+        postService.updatePostsMbti(userId, newMbti);
+    }
+}

--- a/travel/src/main/resources-local/application.yml
+++ b/travel/src/main/resources-local/application.yml
@@ -22,6 +22,23 @@ spring:
         format_sql: true
         show_sql: true
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: travel-service-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: '*'
+
+app:
+  kafka:
+    topics:
+      user-mbti-changed: user-mbti-changed-topic
+
   servlet:
     multipart:
       maxFileSize: 10MB # 파일 하나의 최대 크기

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -52,11 +52,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
 
 //    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:4.1.3'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/user/src/main/java/com/zerobase/user/config/KafkaProducerConfig.java
+++ b/user/src/main/java/com/zerobase/user/config/KafkaProducerConfig.java
@@ -1,0 +1,29 @@
+package com.zerobase.user.config;
+
+import com.zerobase.user.kafka.UserMbtiChangedEvent;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, UserMbtiChangedEvent> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, org.springframework.kafka.support.serializer.JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, UserMbtiChangedEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/user/src/main/java/com/zerobase/user/kafka/UserMbtiChangedEvent.java
+++ b/user/src/main/java/com/zerobase/user/kafka/UserMbtiChangedEvent.java
@@ -1,0 +1,13 @@
+package com.zerobase.user.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserMbtiChangedEvent {
+    private Long userId;
+    private String newMbti;
+}

--- a/user/src/main/resources-local/application.yml
+++ b/user/src/main/resources-local/application.yml
@@ -34,6 +34,16 @@ spring:
         format_sql: true
         use_sql_comments: true
         #show_sql: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+app:
+  kafka:
+    topics:
+      user-mbti-changed: user-mbti-changed-topic
 
 server:
   tomcat:
@@ -45,7 +55,7 @@ server:
 logging:
   level:
     root: INFO # 기본 로그 레벨은 INFO로 설정
-    com.springboot.noticeboard: DEBUG # 필요한 패키지만 DEBUG로 설정
+    com.springboot.user: DEBUG # 필요한 패키지만 DEBUG로 설정
     org.hibernate.SQL: INFO # Hibernate의 SQL 로그를 INFO로 제한
     org.hibernate.type: OFF # Hibernate 타입 로그는 OFF로 설정하여 상세 로그 비활성화
 


### PR DESCRIPTION
🔍 **PR을 통해 해결하려는 문제**

- **사용자 MBTI 정보 동기화 문제**: 사용자가 자신의 MBTI를 수정할 경우, `travel` 모듈에서 해당 사용자가 작성한 모든 여행 게시물의 MBTI 정보가 자동으로 업데이트되지 않는 문제가 있었습니다. 이는 사용자 프로필과 게시물 사이의 MBTI 정보 불일치로 이어져 사용자 경험을 저해할 수 있습니다.

🔑 **PR에서 핵심적으로 변경된 사항**

1. **Kafka를 이용한 이벤트 기반 아키텍처 구현**

   - **이벤트 발행 (`user` 모듈)**:
     - 사용자의 MBTI가 변경될 때 `UserMbtiChangedEvent` 이벤트를 Kafka 토픽으로 발행하도록 구현했습니다.
     - `ProfileService`에 MBTI 변경 시 이벤트를 발행하는 로직을 추가했습니다.

   - **이벤트 수신 (`travel` 모듈)**:
     - `UserMbtiChangedEventListener`를 생성하여 Kafka 토픽으로부터 이벤트를 수신합니다.
     - 수신된 이벤트를 기반으로 해당 사용자의 모든 게시물의 MBTI 정보를 업데이트합니다.

2. **Kafka 설정 추가 및 수정**

   - **의존성 추가 (`build.gradle`)**:
     - `org.springframework.kafka:spring-kafka` 라이브러리를 추가하여 Kafka를 활용할 수 있도록 했습니다.
     - 테스트를 위한 `spring-kafka-test` 의존성을 추가했습니다.

   - **설정 파일 수정 (`application.yml`)**:
     - Kafka 서버 주소 및 기본 설정을 추가했습니다.
     - 이벤트 주제(topic) 이름을 설정했습니다 (`user-mbti-changed-topic`).

3. **이벤트 클래스 생성**

   - `UserMbtiChangedEvent` 클래스를 `user` 및 `travel` 모듈에 생성하여 이벤트의 데이터 구조를 정의했습니다.
   - 이벤트에는 `userId`와 `newMbti` 필드가 포함되어 있습니다.

4. **Kafka 프로듀서 및 컨슈머 설정**

   - **`user` 모듈**:
     - `KafkaProducerConfig`를 생성하여 Kafka 프로듀서 설정을 구성했습니다.
     - `KafkaTemplate`을 빈으로 등록하여 이벤트 발행에 사용했습니다.

   - **`travel` 모듈**:
     - `KafkaConsumerConfig`를 생성하여 Kafka 컨슈머 설정을 구성했습니다.
     - `ConcurrentKafkaListenerContainerFactory`를 빈으로 등록하여 이벤트 수신에 사용했습니다.

5. **데이터베이스 업데이트 로직 추가**

   - **`PostRepository` 수정**:
     - 사용자 ID를 기반으로 게시물의 MBTI를 업데이트하는 `updateMbtiByUserId` 메서드를 추가했습니다.
     - `@Modifying` 및 `@Query` 어노테이션을 사용하여 벌크 업데이트를 수행합니다.

   - **`PostService` 수정**:
     - `updatePostsMbti` 메서드를 추가하여 서비스 레벨에서 MBTI 업데이트를 처리합니다.

6. **엔티티 수정**

   - **`PostEntity`에 `mbti` 필드 추가**:
     - 게시물 엔티티에 `MBTI` 필드를 추가하여 각 게시물에 작성자의 MBTI를 저장하도록 했습니다.
     - 이를 통해 게시물 조회 시 작성자의 MBTI 정보를 함께 제공할 수 있습니다.

📄 **핵심 변경 사항 외에 추가적으로 변경된 부분**

- **로컬 환경 설정 (`application-local.yml`)**

  - 개발 환경에서 Kafka를 사용할 수 있도록 로컬 설정 파일에 Kafka 관련 설정을 추가했습니다.
  - `dev` 환경의 설정 파일은 팀원과의 협의 후 추후 변경할 예정입니다.

- **로그 설정 수정**

  - `application.yml`에서 로깅 레벨을 조정하여 디버깅 시 불필요한 로그가 출력되지 않도록 했습니다.

- **불필요한 코드 및 주석 제거**

  - 코드의 가독성을 높이기 위해 사용되지 않는 주석과 코드를 정리했습니다.

- **예외 처리 추가**

  - `PostService`에서 MBTI 값을 열거형으로 변환할 때 발생할 수 있는 `IllegalArgumentException`을 처리하여 안정성을 높였습니다.

---

이번 PR을 통해 사용자 MBTI 정보 변경 시 `user`와 `travel` 모듈 간의 데이터 동기화를 구현하여 사용자 경험을 개선했습니다. 이벤트 기반 아키텍처를 도입함으로써 모듈 간 결합도를 낮추고 확장성을 높였습니다.