### PR TITLE
여행 게시물 목록 보여줄때 삭제된것과 모집마감글은 제외하고 보여줌.

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -237,8 +237,8 @@ public class PostService {
             throw new BizException(PERMISSION_DENIED_ERROR);
         }
 
-        // 게시글 삭제
-        postRepository.delete(existingPost);
+        // 게시글 삭제 Soft Delete로 변경
+        existingPost.setStatus(PostStatus.DELETED);
     }
 
     @Transactional
@@ -370,7 +370,7 @@ public class PostService {
         postRepository.updateMbtiByUserId(mbtiEnum, userId);
     }
 
-    @Scheduled(cron = "0 0 * * * *") // 매 시간마다 실행
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     @Transactional
     public void updatePostStatus() {
         LocalDate now = LocalDate.now();

--- a/travel/src/main/java/com/zerobase/travel/post/specification/PostSpecification.java
+++ b/travel/src/main/java/com/zerobase/travel/post/specification/PostSpecification.java
@@ -1,10 +1,13 @@
 package com.zerobase.travel.post.specification;
 
+import static com.zerobase.travel.post.type.PostStatus.*;
+
 import com.zerobase.travel.post.dto.request.PostSearchCriteria;
 import com.zerobase.travel.post.entity.DayDetailEntity;
 import com.zerobase.travel.post.entity.DayEntity;
 import com.zerobase.travel.post.entity.PostEntity;
 import com.zerobase.travel.post.constants.RepresentativeCountries;
+import com.zerobase.travel.post.type.PostStatus;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import org.springframework.data.jpa.domain.Specification;
@@ -59,6 +62,14 @@ public class PostSpecification {
                 predicate = cb.and(predicate,
                     cb.equal(root.get("travelCountry"), criteria.getCountry()));
             }
+
+            // 상태가 RECRUITMENT_COMPLETED 또는 DELETED가 아닌 게시글만 조회
+            predicate = cb.and(predicate,
+                cb.not(root.get("status").in(
+                    RECRUITMENT_COMPLETED,
+                    DELETED
+                ))
+            );
 
             return predicate;
         };


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
여행 게시물 목록 보여줄때 삭제된것과 모집마감글은 제외하고 보여줌.

## 🔑 PR에서 핵심적으로 변경된 사항
게시물 전체 보여줌 ->  삭제된것과 모집마감글은 제외하고 보여줌.

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
없음
