### PR TITLE
feat) payclient 도입 , refactor) transaction제거를 위한 로직 및 데이터 상태 세분화

### DIFF
--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -18,17 +18,15 @@ public class DepositService {
 
 
     // depositId를 생성하기 위해서
-    public DepositDto createDepositOrder(Long postId, Long participationId,
+    public DepositEntity createDepositOrder(Long postId, Long participationId,
         String userId) {
         log.info("DepositRepository initial save start");
 
-        DepositEntity depositEntity = DepositEntity.builder()
+        return DepositEntity.builder()
             .postId(postId)
             .participationId(participationId)
             .userId(userId)
             .build();
-
-        return DepositDto.fromEntity(depositRepository.save(depositEntity));
     }
 
 
@@ -36,5 +34,9 @@ public class DepositService {
         return DepositDto.fromEntity(depositRepository
             .findByParticipationId(participationId).orElseThrow(
             CustomException::new));
+    }
+
+    public void save(DepositEntity depositEntity) {
+        depositRepository.save(depositEntity);
     }
 }

--- a/travel/src/main/java/com/zerobase/travel/api/PayApi.java
+++ b/travel/src/main/java/com/zerobase/travel/api/PayApi.java
@@ -1,0 +1,22 @@
+package com.zerobase.travel.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Component
+@RequiredArgsConstructor
+public class PayApi {
+
+    private final PayClient payClient;
+
+    public ResponseEntity<Object> payDepositRefund(@PathVariable long participationId) {
+
+        payClient.payDepositRefund(participationId);
+
+        return ResponseEntity.ok().build();
+    }
+
+
+}

--- a/travel/src/main/java/com/zerobase/travel/api/PayClient.java
+++ b/travel/src/main/java/com/zerobase/travel/api/PayClient.java
@@ -1,0 +1,17 @@
+package com.zerobase.travel.api;
+
+import com.zerobase.travel.common.response.ResponseMessage;
+import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+
+
+@FeignClient(name = "pay-service", url = "${pay-service.url}") // application.yml에 정의된 URL 사용
+public interface PayClient {
+
+    @PutMapping("/internal/api/v1/pay/deposit/byParticipation/{participationId}/refund")
+    ResponseEntity<Object> payDepositRefund(@PathVariable() long participationId);
+
+}

--- a/travel/src/main/java/com/zerobase/travel/controller/InternalParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/InternalParticipationController.java
@@ -1,0 +1,45 @@
+package com.zerobase.travel.controller;
+
+import com.zerobase.travel.service.ParticipationManagementService;
+import com.zerobase.travel.service.ParticipationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/internal/api/v1/posts/participations")
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class InternalParticipationController {
+
+    private final ParticipationService participationService;
+    private final ParticipationManagementService participationManagementService;
+
+
+    // 참여 확정 : 프론트에서 결제가 완료되면 호출하도록 이벤트 설정
+    @PutMapping("/{participationId}/success")
+    public ResponseEntity<Void> confirmParticipation(
+        @PathVariable long participationId, @RequestHeader("X-User-Id") String userId) {
+        log.info("success participation controller start");
+        participationManagementService.successPaymentParticipation(participationId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 참여 확정 : 프론트에서 결제가 완료되면 호출하도록 이벤트 설정
+    @PutMapping("/{participationId}/fail")
+    public ResponseEntity<Void> failParticipation(
+        @PathVariable long participationId, @RequestHeader("X-User-Id") String userId) {
+        log.info("failed participation controller start");
+        participationManagementService.failedPaymentParticipation(participationId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+
+
+
+}

--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -27,19 +27,20 @@ public class ParticipationController {
 
     // 참여
     @PostMapping("{postId}/participations")
-    public ParticipationDto createParticipation(
+    public ParticipationDto readyParticipation(
         @PathVariable Long postId, @RequestHeader("X-User-Id") String userId) {
         log.info("createParticipation controller start");
-        return participationService.createParticipation(postId, userId);
-
+        return participationManagementService.readyParticipation(postId, userId);
     }
+
+
 
     // 개인의 참여취소
     @DeleteMapping("{postId}/participations")
     public ResponseEntity<Object> deleteParticipations( @PathVariable Long postId,  @RequestHeader(value="userId") String userId ) {
 
         log.info("deleteParticipations controller start");
-        participationManagementService.unjoinWithDepositTakenParticipation(postId,userId);
+        participationManagementService.unjoinParticipationWithDepositForfeited(postId,userId);
 
         return ResponseEntity.ok().build();
     }

--- a/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Repository;
 public interface ParticipationRepository extends JpaRepository<ParticipationEntity,Long> {
 
 
-    int countByParticipationStatusAndUserId(ParticipationStatus participationStatus, String userId);
+    int countByUserIdAndParticipationStatusIn(String userId, List<ParticipationStatus> participationStatuses);
   
     Optional<ParticipationEntity> findByPostEntityPostIdAndUserId(Long postId, String userId);
 
     List<ParticipationEntity> findAllByPostEntityPostIdAndParticipationStatus(Long postId, ParticipationStatus participationStatus);
 
 
-
+    int countByPostEntityPostIdAndParticipationStatusIn(Long postId, List<ParticipationStatus> join);
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -1,5 +1,6 @@
 package com.zerobase.travel.service;
 
+import com.zerobase.travel.api.PayApi;
 import com.zerobase.travel.communities.type.CustomException;
 import com.zerobase.travel.communities.type.ErrorCode;
 import com.zerobase.travel.dto.ParticipationDto;
@@ -12,7 +13,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
 /*
@@ -22,15 +22,16 @@ deposit에 대한 처리와 participation 데이터를 관리하는 service
 
  Participation Status를 변화시키는 모든 비즈니스 케이스 반영
 1. 여행을 참가
-2. 여행을 투표를 통해서 전체 취소
+1.1 여행을 참가를 눌렀지만 결제처리에서 에러가 난경우 :
+1.1 여행 참가를 눌러서 결재 완료가 정상처리 된 경우 : pay모듈에서 수신
+1.2 여행 참가를 눌러서 혹은 결제실패 처리가 정상처리가 된 경우 : pay모듈에서 수신
+2. 여행을 투표를 통해서 전체 취소 : pay모듈로 발신
 3. 여행을 자진, 신고를 통해서 개인 취소
 4. 여행을 전체 완료 (평점안매김)
 5. 여행을 왼료한 후에 평점을 매김
 5.1 평점을 여행완료 후 7일 이후에 매긴 경우
 5.2 평점을 여행완료 후 7일 전에 매긴 경우
-
-
-6. 여행을 완료한 후에  보증금이 반환됨
+6. 여행을 완료한 후에  보증금이 반환됨 : pay모듈로 발신
 
 
  */
@@ -42,76 +43,101 @@ deposit에 대한 처리와 participation 데이터를 관리하는 service
 public class ParticipationManagementService {
 
 
+
+
     private final ParticipationService participationService;
+    private final PayApi payApi;
 
-    // 1. 여행을 참가
-    // todo : TRANSACTION 처리기간이 길어서 phantom read 같은 문제 발생 가능성에 대해서 고민할 것, snapshot과 데이터 왜곡?
-    @Transactional
-    public ParticipationDto createParticipation(Long postId, String userId) {
 
-        ParticipationDto participation = participationService.createParticipation(
+
+
+    // 1. 여행을 참가 ; 여행참가 ~ 지불까지를 하나의 트랜잭션으로 묶기에는 과도하게 길어서 분리.
+    // JoinReady 상태 임시저장 -> client 에서 결제준비요청 -> 결제완료/실패시 서버에 응답
+    public ParticipationDto readyParticipation(Long postId, String userId) {
+
+        participationService.validateParticipationApplicant(postId,userId);
+
+        return participationService.createParticipationReady(
             postId, userId);
+    }
 
-        //보증금 지불준비 API호출
+     //1.1 여행을 참가를 눌렀지만 결제처리에서 에러가 난경우
+    public void failedPaymentParticipation(long participationId, String userId) {
 
-        //보증금 지급완료 API유저신호 수신
+        // participation, userId를 통해서 participationEntity호출
+        ParticipationEntity participationEntity = participationService
+            .validateParticipationUserId(participationId, userId);
 
-        // 전체 트랙잭션 처리
+        // fail에 따른 상태검증 및 상태변경
+        participationService.checkAndChangeStatusParticipation(
+            participationEntity,
+            List.of(ParticipationStatus.JOIN_READY,DepositStatus.UNPAID),
+            List.of(ParticipationStatus.JOIN_FAILED));
 
-        return participation;
+        participationService.saveParticipation(participationEntity);
+    }
+
+
+
+    // 1.2 여행 참가를 눌러서 결재 완료 혹은 결제실패 처리가 정상처리가 된 경우
+    public void successPaymentParticipation(long participationId, String userId) {
+
+        // participation, userId를 통해서 participationEntity호출
+        ParticipationEntity participationEntity = participationService
+            .validateParticipationUserId(participationId, userId);
+
+        // confirm에 따른 상태 검증 및 변경
+        participationService.checkAndChangeStatusParticipation(
+            participationEntity,
+            List.of(ParticipationStatus.JOIN_READY,DepositStatus.UNPAID),
+            List.of(ParticipationStatus.JOIN, DepositStatus.PAID));
+
+        participationService.saveParticipation(participationEntity);
+
     }
 
 
     //2. 여행을 투표를 통해서 취소, 투표완료시 해당 메소드 호출
-    @Transactional
-    public void unjoinWithDepositReturnedParticipation(Long postId,
+    public void unjoinParticipationWithDepositReturned(Long postId,
         String userId) {
 
         // postId, userId를 통해서 participationEntity호출
         ParticipationEntity participationEntity = participationService
             .getParticipationEntityByPostIdAndUserId(postId, userId);
 
-        // 배당금 반환 API 호출
-        try {
+        // 상태를 검증하고 변환
+        participationService.checkAndChangeStatusParticipation(
+            participationEntity,
+            List.of(ParticipationStatus.JOIN,DepositStatus.PAID),
+            List.of(ParticipationStatus.JOIN_CANCEL, DepositStatus.RETURNED));
 
-        } catch (Exception e) {
-
-        }
+        // pay모듈에 취소요청
+        payApi.payDepositRefund(participationEntity.getParticipationId());
 
         // deposit 반환시점 기록
         participationService.setDateToReturnDeposit(participationEntity,
             LocalDate.now());
 
-        // 상태를 변환하고 저장
-        participationService.checkAndChangeStatusToSaveParticipation(
-            participationEntity, List.of(ParticipationStatus.JOIN),
-            List.of(ParticipationStatus.JOIN_CANCEL,
-                DepositStatus.DEPOSIT_RETURNED));
-
+        // 검증 - 보증금반환까지 fail 이 안나면 저장
+        participationService.saveParticipation(participationEntity);
     }
 
 
     // 3. 여행을 자진, 신고를 통해서 개인 취소하여 배당금 몰수
-    @Transactional
-    public void unjoinWithDepositTakenParticipation(Long postId,
+    public void unjoinParticipationWithDepositForfeited(Long postId,
         String userId) {
 
         // postId, userId를 통해서 participationEntity호출
         ParticipationEntity participationEntity = participationService
             .getParticipationEntityByPostIdAndUserId(postId, userId);
 
-        // 배당금 몰수 API 호출
-        try {
+        // 상태를 검증하고 변환
+        participationService.checkAndChangeStatusParticipation(
+            participationEntity,
+            List.of(ParticipationStatus.JOIN,DepositStatus.PAID),
+            List.of(ParticipationStatus.JOIN_CANCEL, DepositStatus.FORFEITED));
 
-        } catch (Exception e) {
-
-        }
-
-        // 상태를 변환하고 저장
-        participationService.checkAndChangeStatusToSaveParticipation(
-            participationEntity, List.of(ParticipationStatus.JOIN),
-            List.of(ParticipationStatus.JOIN_CANCEL,
-                DepositStatus.DEPOSIT_TAKEN));
+        participationService.saveParticipation(participationEntity);
     }
 
     // 4. 인원이 시간이 지나서 여행을 완료하는 경우;
@@ -123,15 +149,17 @@ public class ParticipationManagementService {
         ParticipationEntity participationEntity = participationService
             .getParticipationEntityByPostIdAndUserId(postId, userId);
 
+        // 참여의 상태를 검증하고 변경
+        participationService.checkAndChangeStatusParticipation(
+            participationEntity,
+            List.of(ParticipationStatus.JOIN),
+            List.of(ParticipationStatus.TRAVEL_FINISHED));
+
         // 보증금 반환일자를 확정
         participationService.setDateToReturnDeposit(participationEntity,
             LocalDate.now().plusDays(30));
 
-        // 참여의 상태를 변경 ; 여행완료
-        participationService.checkAndChangeStatusToSaveParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN),
-            List.of(ParticipationStatus.TRAVEL_FINISHED));
+        participationService.saveParticipation(participationEntity);
     }
 
 
@@ -142,7 +170,7 @@ public class ParticipationManagementService {
 
     // todo : 아래의 의문사항이 있지만 일단 단순한 상황을 가정해서 코딩후 리팩토링필요
     // what if1. 여행보증금 지급일로 보증금지급시점을 관리하는데, 보증금 지급일 변경과 지급이 동시에
-    // 이루어지는 경쟁상황은 어떻게 처리할 것인지? 정책적 해결, 기술적 해결.
+    // 이루어지는 경쟁상황은 어떻게 처리할 것인지? 정책적 해결, 기술적 해결방법 고려
     // what if2. 평점을 매긴 날짜가 여행완료후 7일이후일경우에 바로 보증금 반환 혹은 다음날 반환?
 
 
@@ -151,21 +179,22 @@ public class ParticipationManagementService {
         ParticipationEntity entity = participationService
             .getParticipationEntityByPostIdAndUserId(postId, userId);
 
+        // 보증금 일자가 정해지지 않았다면 여행이 미완료된 것으로 간주하여 fail
         if(entity.getDepositReturnDate()==null){
             throw new CustomException(ErrorCode.PARTICIPATION_STATUS_ERROR);
         }
 
-        //5.1 평점을 보증금 기본반환일이나 그 이후(여행완료 후 30일 이후)에 매긴 경우, 평점상태만 변경
+        //5.1 보증금 기본 반환일이나 그 이후에 평가한 경우, 평점상태만 변경
         if(LocalDate.now().isAfter(entity.getDepositReturnDate().minusDays(1))){
-            participationService.checkAndChangeStatusToSaveParticipation(
+            participationService.checkAndChangeStatusParticipation(
                 entity,
-                List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED), // 자정에 평가하는 문제때문에 우선 deposit 상태는 검증 x
+                // 자정에 평가하는 문제때문에 우선 deposit 상태는 검증 x
+                List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED),
                 List.of(RatingStatus.RATED)
             );
         }
 
         //5.2 평점을 여행완료 후 7일이거나 그 이후 그리고 30일이전에 매긴 경우, 다음날을 보증금 지급일 변경 ? 확인필요
-
         if(LocalDate.now().isBefore(entity.getDepositReturnDate())
         &&LocalDate.now().isAfter(entity.getDepositReturnDate().minusDays(23))){
 
@@ -173,10 +202,10 @@ public class ParticipationManagementService {
             participationService.setDateToReturnDeposit(entity,
                 LocalDate.now().plusDays(1));
 
-            participationService.checkAndChangeStatusToSaveParticipation(
+            participationService.checkAndChangeStatusParticipation(
                 entity,
                 List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED,
-                    DepositStatus.DEPOSIT_PAID),
+                    DepositStatus.PAID),
                 List.of(RatingStatus.RATED)
             );
         }
@@ -187,21 +216,17 @@ public class ParticipationManagementService {
             participationService.setDateToReturnDeposit(entity,
                 entity.getDepositReturnDate().minusDays(23));
 
-            participationService.checkAndChangeStatusToSaveParticipation(
+            participationService.checkAndChangeStatusParticipation(
                 entity,
                 List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED
-                    ,DepositStatus.DEPOSIT_PAID),
+                    ,DepositStatus.PAID),
                 List.of(RatingStatus.RATED)
             );
-
-
         }
-
-
     }
 
     // 6. 여행을 왼료한 후에 보증금이 반환됨
-    public void returnDepositAfterTravelParticipation(Long postId,
+    public void returnDepositAfterTravelFinished(Long postId,
         String userId) {
 
         // 매일 보증금 반환시점을 확인하고 보증금 반환을 확인하는 logic 추가
@@ -210,26 +235,18 @@ public class ParticipationManagementService {
         ParticipationEntity participationEntity = participationService
             .getParticipationEntityByPostIdAndUserId(postId, userId);
 
-
-
-        // 배당금 반환 API 호출
-        try {
-
-        } catch (Exception e) {
-
-        }
-
-        // 보증금 반환 상태를 변경후 저장
-
-        participationService.checkAndChangeStatusToSaveParticipation(
+        // 보증금 반환 상태를 검증 후 상태 변환
+        participationService.checkAndChangeStatusParticipation(
             participationEntity,
-            List.of(ParticipationStatus.TRAVEL_FINISHED, DepositStatus.DEPOSIT_PAID),
-            List.of( DepositStatus.DEPOSIT_RETURNED)
+            List.of(ParticipationStatus.TRAVEL_FINISHED, DepositStatus.PAID),
+            List.of( DepositStatus.RETURNED)
         );
 
+        // 배당금 반환 API 호출
+        payApi.payDepositRefund(participationEntity.getParticipationId());
 
+        participationService.saveParticipation(participationEntity);
 
     }
-
 
 }

--- a/travel/src/main/java/com/zerobase/travel/type/DepositStatus.java
+++ b/travel/src/main/java/com/zerobase/travel/type/DepositStatus.java
@@ -1,8 +1,10 @@
 package com.zerobase.travel.type;
 
 public enum DepositStatus {
-    DEPOSIT_PAID,
-    DEPOSIT_TAKEN,
-    DEPOSIT_RETURNED
+
+    UNPAID,
+    PAID,
+    FORFEITED,
+    RETURNED
 
 }

--- a/travel/src/main/java/com/zerobase/travel/type/ParticipationStatus.java
+++ b/travel/src/main/java/com/zerobase/travel/type/ParticipationStatus.java
@@ -1,6 +1,8 @@
 package com.zerobase.travel.type;
 
 public enum ParticipationStatus {
+    JOIN_READY,
+    JOIN_FAILED,
     JOIN,
     JOIN_CANCEL,
     TRAVEL_FINISHED


### PR DESCRIPTION
note:  코드를 작성하다보니 PR내에 내용/코드 정리가 잘 되지 않고 PR 길이가 길어졌네요. 
금일 PR 여러 건이 퀄리티가 좋지 않을 것같습니다. 최대한 정리를 좀 해보겠지만 양해부탁드립니다.

## 🔍 PR을 통해 해결하려는 문제
1. Transactional annotation 제거를 위한 Participation Entity 상태추가 
2. Transaction annotation 제거를 위한 메소드, 메소드 호출 구조변경
3. Pay모듈 Travel모듈 연결을 위한 payclient 생성

## 🔑 PR에서 핵심적으로 변경된 사항

1. Transactional annotation 제거를 위한 Participation Entity, Deposit Entity 상태추가 

**AS-IS**
트랜잭션 처리를 통해서 결제가 완료된 경우에만 Participation, Deposit 데이터를 생성하도록 처리
-> 해당 방식은 외부 API를 호출하고 유저가 결제를 하는 동안 Transaction 처리하는 방식으로 Lock이 걸리는 기간이 매우김

**TO-BE**
결제전 단계를 도입하여 participation Join ready, deposit unpaid 상태로 우선 데이터 생성 그 후 결제를 시도하여 성공시 상태변경을 저장
->  join ready, deposit unpaid는 외부 API가 실패할 경우에만 잔류하며 예외처리로 데이터 정리하여 데이터 무결성 확보예정

2.  Transaction annotation 제거를 위한 ParticipationService 메소드, 메소드 호출 구조변경

**AS-IS**
서비스 로직을 <외부API호출+데이터상태변경 및 저장>을 트랜잭션 처리하여 API실패시 데이터 무결성 확보

**TO-BE**
서비스 로직을 <데이터 상태변경 + 외부API호출 + 저장>순서로 변경하여 API호출이 실패하면 저장되지 않도록 메소드 세분화 및 메소드 호출 순서변경 

3. Pay모듈 Travel모듈 연결을 위한 payclient 생성

**AS-IS**
최초도입

**TO-BE**
최초도입

