### PR TITLE
삭제된 여행 게시물 조회할때 게시글 찾을수 없다는 에러 메시지 응답.

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -249,6 +249,10 @@ public class PostService {
         PostEntity existingPost = postRepository.findById(postId)
             .orElseThrow(() -> new BizException(POST_NOT_FOUND_ERROR));
 
+        if(PostStatus.DELETED.equals(existingPost.getStatus())){
+            throw new BizException(POST_NOT_FOUND_ERROR);
+        }
+
         // ResponsePostDTO 빌드
         return ResponsePostDTO.builder()
             .userId(existingPost.getUserId())


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
삭제된 여행 게시물 조회할때 게시글 찾을수 없다는 에러 메시지 응답.

## 🔑 PR에서 핵심적으로 변경된 사항
기존 삭제된 여행 게시물도 조회 되었지만, 삭제처리되면 게시글을 찾을 수 없다는 에러 메시지 응답으로 변경/

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
없음.