### PR TITLE
Fix) Participation controller userId 받는 방식 변경

### DIFF
--- a/pay/src/main/java/com/zerobase/entity/DepositEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/DepositEntity.java
@@ -2,6 +2,8 @@ package com.zerobase.entity;
 
 import com.zerobase.model.type.PaymentStatus;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,5 +28,6 @@ public class DepositEntity {
     private Long postId;
     private Long participationId;
     private String userId;
+    @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
 }

--- a/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/KakaoPayPaymentHistoryEntity.java
@@ -3,6 +3,8 @@ package com.zerobase.entity;
 import com.zerobase.model.type.KaKaoPayStatus;
 import com.zerobase.model.type.PayMethod;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +27,9 @@ public class KakaoPayPaymentHistoryEntity {
     private String tid;
     private String partnerOrderId;
     private String partnerUserId;
+    @Enumerated(EnumType.STRING)
     private KaKaoPayStatus kaKaoStatus;
+    @Enumerated(EnumType.STRING)
     private PayMethod payMethod;
     private Long amount;
 }

--- a/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
+++ b/pay/src/main/java/com/zerobase/entity/PaymentEntity.java
@@ -4,6 +4,8 @@ import com.zerobase.model.type.OrderType;
 import com.zerobase.model.type.PGMethod;
 import com.zerobase.model.type.PaymentStatus;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,10 +31,13 @@ public class PaymentEntity {
     private Long amount;
     // 결제라는 개념이 단순히 deposit에 종속된 개념이 아니라 deposit을 포함하는 상위개념으로
     // 취급하기 위해서 depositstatus 와 별개로 Paymentstatus 를 두고 관리함. 다른 아이템에 확장가능하도록.
+    @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
+    @Enumerated(EnumType.STRING)
     private PGMethod pgMethod;
 
     // 여기서는 deposit
+    @Enumerated(EnumType.STRING)
     private OrderType referentialOrderType;
     // 여기서는 deposit_id
     private Long referentialOrderId;

--- a/pay/src/main/java/com/zerobase/model/exception/CustomException.java
+++ b/pay/src/main/java/com/zerobase/model/exception/CustomException.java
@@ -1,5 +1,6 @@
 package com.zerobase.model.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +8,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomException extends RuntimeException {
+
+    ErrorCode errorCode;
 
 }

--- a/pay/src/main/java/com/zerobase/model/exception/ErrorCode.java
+++ b/pay/src/main/java/com/zerobase/model/exception/ErrorCode.java
@@ -1,0 +1,5 @@
+package com.zerobase.model.exception;
+
+public enum ErrorCode {
+    DEPOSIT_NOT_EXSITING, PAYMENT_NOT_EXSITING, INVALID_CLIENT_REQUEST
+}

--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -4,6 +4,7 @@ import com.zerobase.api.ParticipationApi;
 import com.zerobase.entity.DepositEntity;
 import com.zerobase.model.DepositDto;
 import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.exception.ErrorCode;
 import com.zerobase.model.type.PaymentStatus;
 import com.zerobase.repository.DepositRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +41,7 @@ public class DepositService {
     public DepositDto findByParticipationId(Long participationId) {
         return DepositDto.fromEntity(depositRepository
             .findByParticipationId(participationId).orElseThrow(
-                CustomException::new));
+                () -> new CustomException(ErrorCode.DEPOSIT_NOT_EXSITING)));
     }
 
     public void save(DepositEntity depositEntity) {
@@ -51,7 +52,7 @@ public class DepositService {
         String userId) {
         if (Boolean.FALSE.equals(participationAPi.validateParticipationInfo
                 (postId, participationId, userId).getBody())) {
-            throw new CustomException();
+            throw new CustomException(ErrorCode.INVALID_CLIENT_REQUEST);
         }
 
 
@@ -61,7 +62,8 @@ public class DepositService {
         long depositId,
         PaymentStatus paymentStatus) {
         DepositEntity depositEntity = depositRepository.findById(depositId)
-            .orElseThrow(() -> new CustomException());
+            .orElseThrow(() -> new CustomException(
+                ErrorCode.DEPOSIT_NOT_EXSITING));
 
         depositEntity.setPaymentStatus(paymentStatus);
 
@@ -72,7 +74,8 @@ public class DepositService {
         long depositId,
         PaymentStatus paymentStatus) {
         DepositEntity depositEntity = depositRepository.findById(depositId)
-            .orElseThrow(() -> new CustomException());
+            .orElseThrow(() -> new CustomException(
+                ErrorCode.DEPOSIT_NOT_EXSITING));
 
         depositEntity.setPaymentStatus(paymentStatus);
 

--- a/pay/src/main/java/com/zerobase/service/PayManagementService.java
+++ b/pay/src/main/java/com/zerobase/service/PayManagementService.java
@@ -11,6 +11,7 @@ import com.zerobase.model.PaymentDto;
 import com.zerobase.model.ResponseApi;
 import com.zerobase.model.ResponseDepositPayDto;
 import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.exception.ErrorCode;
 import com.zerobase.model.type.PGMethod;
 import com.zerobase.model.type.PaymentStatus;
 import java.util.Objects;
@@ -152,7 +153,7 @@ public class PayManagementService {
 
         if(!Objects.equals(depositEntity.getUserId(), userId)
             || !Objects.equals(paymentEntity.getUserId(), userId)){
-            throw new CustomException();
+            throw new CustomException(ErrorCode.INVALID_CLIENT_REQUEST);
         }
 
         kakaopayApi.sendPayRefundSign(

--- a/pay/src/main/java/com/zerobase/service/PaymentService.java
+++ b/pay/src/main/java/com/zerobase/service/PaymentService.java
@@ -3,6 +3,7 @@ package com.zerobase.service;
 import com.zerobase.config.Constants;
 import com.zerobase.entity.PaymentEntity;
 import com.zerobase.model.exception.CustomException;
+import com.zerobase.model.exception.ErrorCode;
 import com.zerobase.model.type.OrderType;
 import com.zerobase.model.type.PGMethod;
 import com.zerobase.model.PaymentDto;
@@ -58,7 +59,8 @@ public class PaymentService {
         long depositId, PaymentStatus paymentStatus) {
 
         PaymentEntity paymentEntity = paymentRepository.findByReferentialOrderIdAndPaymentStatus(
-            depositId, PaymentStatus.PAY_IN_PROGRESS).orElseThrow(() -> new CustomException());
+            depositId, PaymentStatus.PAY_IN_PROGRESS).orElseThrow(() -> new CustomException(
+            ErrorCode.PAYMENT_NOT_EXSITING));
 
         paymentEntity.setPaymentStatus(paymentStatus);
 
@@ -68,9 +70,11 @@ public class PaymentService {
 
     public PaymentEntity getPaymentsInPayCompletedByOrderId( String userId,long orderId) {
         PaymentEntity paymentEntity = paymentRepository.findByReferentialOrderIdAndPaymentStatus(
-            orderId, PaymentStatus.PAY_COMPLETED).orElseThrow(() -> new CustomException());
+            orderId, PaymentStatus.PAY_COMPLETED).orElseThrow(() -> new CustomException(
+            ErrorCode.PAYMENT_NOT_EXSITING));
 
-        if(!Objects.equals(paymentEntity.getUserId(), userId)) throw new CustomException();
+        if(!Objects.equals(paymentEntity.getUserId(), userId)) throw new CustomException(
+            ErrorCode.INVALID_CLIENT_REQUEST);
 
         return paymentEntity;
     }

--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -36,7 +36,7 @@ public class ParticipationController {
 
     // 개인의 참여취소
     @DeleteMapping("{postId}/participations")
-    public ResponseEntity<Object> deleteParticipations( @PathVariable Long postId,  @RequestHeader(value="userId") String userId ) {
+    public ResponseEntity<Object> deleteParticipations( @PathVariable Long postId,  @RequestHeader("X-User-Id") String userId ) {
 
         log.info("deleteParticipations controller start");
         participationManagementService.unjoinParticipationWithDepositForfeited(postId,userId);

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -286,15 +287,18 @@ public class ParticipationService {
     public Boolean validateParticipationUserIdAndPostId(long postId, long participationId,
         String userId) {
 
-        Boolean isValid = true;
+        Optional<ParticipationEntity> optioinal = participationRepository.findById(
+            participationId);
 
-        ParticipationEntity participationEntity = participationRepository.findById(
-            participationId).orElseThrow(()->new CustomException(ErrorCode.PARTICIPATION_NOT_FOUND));
+        if(optioinal.isEmpty()) return false;
+
+        ParticipationEntity participationEntity = optioinal.get();
 
         if(participationEntity.getPostEntity().getPostId() !=postId
             || !Objects.equals(participationEntity.getUserId(), userId)) {
-            isValid = false;
+            return false;
         }
-        return isValid;
+
+        return true;
     }
 }


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
front end와 통합 test전 문제점 hotfix
1. refactor) entity의 enum type String으로 저장
2. fix) controller userId를 x-user-id로 변경
3. refactor) validationParticipation logic을 travel모듈 error도 pay모듈 내에서 excpetion 처리하도록 변경
4. refactor) errorcode 내 메세지 상세화
