### PR TITLE
Feat) 유저가 현재 참여중인 게시글Id 조회기능

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -2,7 +2,7 @@ package com.zerobase.travel.controller;
 
 import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.dto.ParticipationDto;
-import com.zerobase.travel.dto.ResponseParticipationsDto;
+import com.zerobase.travel.dto.ResponseParticipationsByPostDto;
 import com.zerobase.travel.service.ParticipationManagementService;
 import com.zerobase.travel.service.ParticipationService;
 import java.util.List;
@@ -51,12 +51,22 @@ public class ParticipationController {
 
     // 참여자 조회시에 Status에 Join/joinready 상태의 유저 리스트 확인
     @GetMapping("{postId}/participations")
-    public ResponseEntity<ResponseMessage<List<ResponseParticipationsDto>>> getParticipationsByPost(
+    public ResponseEntity<ResponseMessage<List<ResponseParticipationsByPostDto>>> getParticipationsByPost(
         @PathVariable Long postId) {
         log.info("getParticipationsByPost controller start");
         return ResponseEntity.ok(
             ResponseMessage.success(
                 participationService.getParticipationsDtosStatusOfJoin(postId)));
+    }
+
+    // 참여자 조회시에Join/joinready 상태의 자신의 참여 게시글 리스트 확인
+    @GetMapping("/participations")
+    public ResponseEntity<ResponseMessage<List<ResponseParticipationsByUserDto>>> getActiveParticipationsByUser(
+        @RequestHeader("X-User-Id") String userId) {
+        log.info("getParticipationsByPost controller start");
+        return ResponseEntity.ok(
+            ResponseMessage.success(
+                participationService.getParticipationsByUserStatusOfJoinAndJoinReady(userId)));
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -59,14 +59,8 @@ public class ParticipationController {
                 participationService.getParticipationsDtosStatusOfJoin(postId)));
     }
 
-    // 유저들의 완료된 여행에 대해서 숫자 반환
-    @GetMapping("/participations/by-userid/{userId}")
-    public ResponseEntity<ResponseMessage<Integer>> getParticipationsCompletedByUserId(
-        @PathVariable String userId) {
-        log.info("getParticipationsCompletedByUserId controller start");
-        return ResponseEntity.ok(ResponseMessage.success(
-            participationService.countParticipationsCompletedByUserId(userId)));
-    }
+
+
 
 
 }

--- a/travel/src/main/java/com/zerobase/travel/controller/ResponseParticipationsByUserDto.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ResponseParticipationsByUserDto.java
@@ -1,0 +1,29 @@
+package com.zerobase.travel.controller;
+
+import com.zerobase.travel.entity.ParticipationEntity;
+import com.zerobase.travel.type.ParticipationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+public class ResponseParticipationsByUserDto {
+
+    private Long participationId;
+    private Long postId;
+    private ParticipationStatus participationStatus;
+
+    // 최대 참여수 2개이므로 n+1문제는 무시함
+    public static ResponseParticipationsByUserDto fromEntity(ParticipationEntity participationEntity) {
+        return ResponseParticipationsByUserDto.builder()
+            .participationId(participationEntity.getParticipationId())
+            .postId(participationEntity.getPostEntity().getPostId())
+            .participationStatus(participationEntity.getParticipationStatus())
+            .build();
+    }
+}

--- a/travel/src/main/java/com/zerobase/travel/dto/ResponseParticipationsByPostDto.java
+++ b/travel/src/main/java/com/zerobase/travel/dto/ResponseParticipationsByPostDto.java
@@ -1,7 +1,6 @@
 package com.zerobase.travel.dto;
 
 import com.zerobase.travel.entity.ParticipationEntity;
-import com.zerobase.travel.type.ParticipationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,15 +12,15 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ResponseParticipationsDto {
+public class ResponseParticipationsByPostDto {
     private Long participationId;
     private Long postId;
     private String userId;
 
 
 
-    public static ResponseParticipationsDto fromEntity(ParticipationEntity participationEntity) {
-        return ResponseParticipationsDto.builder()
+    public static ResponseParticipationsByPostDto fromEntity(ParticipationEntity participationEntity) {
+        return ResponseParticipationsByPostDto.builder()
             .participationId(participationEntity.getParticipationId())
             .postId(participationEntity.getPostEntity().getPostId())
             .userId(participationEntity.getUserId())

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -3,8 +3,9 @@ package com.zerobase.travel.service;
 import com.zerobase.travel.api.UserApi;
 import com.zerobase.travel.communities.type.CustomException;
 import com.zerobase.travel.communities.type.ErrorCode;
+import com.zerobase.travel.controller.ResponseParticipationsByUserDto;
 import com.zerobase.travel.dto.ParticipationDto;
-import com.zerobase.travel.dto.ResponseParticipationsDto;
+import com.zerobase.travel.dto.ResponseParticipationsByPostDto;
 import com.zerobase.travel.entity.ParticipationEntity;
 import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
 import com.zerobase.travel.post.entity.PostEntity;
@@ -25,7 +26,6 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 
@@ -226,22 +226,36 @@ public class ParticipationService {
             () -> new CustomException(ErrorCode.PARTICIPATION_NOT_FOUND));
 
 
-
-
-
     }
 
 
     // 현재 여행을 참여하고 있는 복수 인원리스트 반환
-    public List<ResponseParticipationsDto> getParticipationsDtosStatusOfJoin(
+    public List<ResponseParticipationsByPostDto> getParticipationsDtosStatusOfJoin(
         Long postId) {
-        log.info("participation getParticipationsStatusOfJoinAndJoin");
+        log.info("service getParticipationsStatusOfJoinAndJoin");
 
         List<ParticipationEntity> participationEntities
             = participationRepository.findAllByPostEntityPostIdAndParticipationStatusIn(
             postId, List.of(ParticipationStatus.JOIN,ParticipationStatus.JOIN_READY));
 
-        return participationEntities.stream().map(ResponseParticipationsDto::fromEntity)
+        return participationEntities.stream().map(
+                ResponseParticipationsByPostDto::fromEntity)
+            .toList();
+    }
+
+
+
+    // 현재 자신이  참여하고 있는 게시글의 리스트 반환
+    public List<ResponseParticipationsByUserDto> getParticipationsByUserStatusOfJoinAndJoinReady(
+        String userId) {
+        log.info("service getParticipationsByUserStatusOfJoinAndJoinReady");
+
+        List<ParticipationEntity> participationEntities
+            = participationRepository.findAllByUserIdAndParticipationStatusIn(
+            userId, List.of(ParticipationStatus.JOIN,ParticipationStatus.JOIN_READY));
+
+        return participationEntities.stream().map(
+            ResponseParticipationsByUserDto::fromEntity)
             .toList();
     }
 


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
FE 요청으로 인해, 유저가 현재 참여중인 게시글 ID조회기능추가

## 🔑 PR에서 핵심적으로 변경된 사항
- Participation과 Post는 oneToMany관계로 연관관계를 통해서 PostId참조
-> 최대 참여개수가 2개인 관계로 N+1문제는 무시함.
->Participation 상태 중 Join ready와 Join 상태 모두 조회되도록 설정

기타변경사항
기존 유사한 기능의 responsedto 명칭변경을 통해 구분명확화

## 📊 테스트    
- [ x] API 테스트 
