### PR TITLE
Refactor) participation status 변환 로직 helper method 도입을 통한 간결화

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/controller/InternalParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/InternalParticipationController.java
@@ -58,7 +58,7 @@ public class InternalParticipationController {
         @RequestHeader("X-User-Id") String userId ) {
 
         return ResponseEntity.ok(participationService
-            .validateParticipationUserIdAndPostId(postId, participationId, userId));
+            .validateParticipationInfoUserIdAndPostId(postId, participationId, userId));
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -56,7 +56,7 @@ public class ParticipationController {
         log.info("getParticipationsByPost controller start");
         return ResponseEntity.ok(
             ResponseMessage.success(
-                participationService.getParticipationsDtosStatusOfJoin(postId)));
+                participationService.getParticipationsDtosByPostIdAndStatusOfJoin(postId)));
     }
 
     // 유저들의 완료된 여행에 대해서 숫자 반환

--- a/travel/src/main/java/com/zerobase/travel/entity/ParticipationEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/entity/ParticipationEntity.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,6 +22,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.Transient;
 
 
 @Entity
@@ -66,13 +66,53 @@ public class ParticipationEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    // A list to hold each status without persisting it to the database
+    // participation 의 상황에 따른 status 모음
     @Transient
-    private List<Enum<?>> statuses;
+    public static List<Enum<?>> beforePayStatuses = List.of(ParticipationStatus.JOIN_READY,DepositStatus.UNPAID,RatingStatus.NOT_RATED);
+    @Transient
+    public static List<Enum<?>> afterPaySuccessStatuses = List.of(ParticipationStatus.JOIN,DepositStatus.PAID,RatingStatus.NOT_RATED);
+    @Transient
+    public static List<Enum<?>> afterPayFailStatuses = List.of(ParticipationStatus.JOIN_FAILED,DepositStatus.UNPAID,RatingStatus.NOT_RATED);
+    @Transient
+    public static List<Enum<?>> afterVotingStatuses = List.of(ParticipationStatus.JOIN_CANCEL,DepositStatus.RETURNED,RatingStatus.NOT_RATED);
+    @Transient
+    public static List<Enum<?>> afterCancelStatuses = List.of(ParticipationStatus.JOIN_CANCEL,DepositStatus.FORFEITED,RatingStatus.NOT_RATED);
+    @Transient
+    public static List<Enum<?>> afterTravelFinishStatusesUnRated = List.of(ParticipationStatus.TRAVEL_FINISHED,DepositStatus.PAID,RatingStatus.NOT_RATED);
 
-    public List<Enum<?>> getStatuses() {
-        statuses = List.of(participationStatus, depositStatus, ratingStatus);
-        return statuses;
+    @Transient
+    public static List<Enum<?>> afterTravelFinishStatusesRated = List.of(ParticipationStatus.TRAVEL_FINISHED,DepositStatus.PAID,RatingStatus.RATED);
+
+
+    @Transient
+    public static List<Enum<?>> afterRatingStatuses = List.of(ParticipationStatus.TRAVEL_FINISHED,DepositStatus.PAID,RatingStatus.RATED);
+    @Transient
+    public static List<Enum<?>> afterTravelFinishStatusesExcludeRating = List.of(ParticipationStatus.TRAVEL_FINISHED,DepositStatus.PAID);
+    @Transient
+    public static List<Enum<?>> afterDepositReturnedExcludeRating = List.of(ParticipationStatus.TRAVEL_FINISHED,DepositStatus.PAID);
+
+
+
+
+    public boolean hasStatus(Enum<?> status) {
+        if (status instanceof ParticipationStatus) {
+            return this.participationStatus == status;
+        } else if (status instanceof DepositStatus) {
+            return this.depositStatus == status;
+        } else if (status instanceof RatingStatus) {
+            return this.ratingStatus == status;
+        }
+        return false;
+    }
+
+    public void updateStatus(Enum<?> status) {
+        if (status instanceof ParticipationStatus) {
+            this.participationStatus = (ParticipationStatus) status;
+        } else if (status instanceof DepositStatus) {
+            this.depositStatus = (DepositStatus) status;
+        } else if (status instanceof RatingStatus) {
+            this.ratingStatus = (RatingStatus) status;
+        }
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/post/repository/PostRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/post/repository/PostRepository.java
@@ -25,5 +25,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long>, JpaSpec
     List<PostEntity> findByDeadlineBeforeAndStatus(LocalDate deadline, PostStatus status);
 
 
-    Optional<PostEntity> findByPostId(long postId);
+    List<PostEntity> findAllPostByDeadlineAndStatus( LocalDate deadline, PostStatus status);
+
+    Optional<PostEntity> findByPostId(Long postId);
 }

--- a/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
@@ -26,4 +26,7 @@ public interface ParticipationRepository extends JpaRepository<ParticipationEnti
 
     List<ParticipationEntity> findAllByPostEntityPostIdAndParticipationStatus(
         Long postId, ParticipationStatus participationStatus);
+
+
+    List<ParticipationEntity> findAllByPostEntityIn(List<PostEntity> postEntities);
 }

--- a/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
@@ -3,6 +3,7 @@ package com.zerobase.travel.repository;
 import com.zerobase.travel.entity.ParticipationEntity;
 import com.zerobase.travel.post.entity.PostEntity;
 import com.zerobase.travel.type.ParticipationStatus;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,4 +30,6 @@ public interface ParticipationRepository extends JpaRepository<ParticipationEnti
 
 
     List<ParticipationEntity> findAllByPostEntityIn(List<PostEntity> postEntities);
+
+    List<ParticipationEntity> findAllByDepositReturnDate(LocalDate now);
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -138,25 +138,28 @@ public class ParticipationManagementService {
 
 
     // 4. 인원이 시간이 지나서 여행을 완료하는 경우;
-    public void travelFinishedParticipation(Long postId, String userId) {
+    public void travelFinishedParticipations() {
 
         // 매일 게시글의 여행완료 시점을 확인 로직 추가
 
-        // 식별한 participation을 호출
-        ParticipationEntity participationEntity = participationService
-            .getParticipationEntityByPostIdAndUserId(postId, userId);
+        List<ParticipationEntity> participationEntities
+            = participationService.findParticipationToCompleteByNow();
 
         // 참여의 상태를 검증하고 변경
-        participationService.checkAndChangeStatusParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN),
-            List.of(ParticipationStatus.TRAVEL_FINISHED));
+        for (ParticipationEntity participationEntity : participationEntities) {
 
-        // 보증금 반환일자를 확정
-        participationService.setDateToReturnDeposit(participationEntity,
-            LocalDate.now().plusDays(30));
+            participationService.checkAndChangeStatusParticipation(
+                participationEntity,
+                List.of(ParticipationStatus.JOIN),
+                List.of(ParticipationStatus.TRAVEL_FINISHED));
 
-        participationService.saveParticipation(participationEntity);
+            // 보증금 반환일자를 확정
+            participationService.setDateToReturnDeposit(participationEntity,
+                LocalDate.now().plusDays(30));
+        }
+
+        participationService.saveParticipations(participationEntities);
+
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 /*
@@ -213,7 +214,6 @@ public class ParticipationManagementService {
 
         //5.3 평점을 여행완료 후 7일 전에 매긴 경우, 보증금 지급일을 여행완료 후 7일후로 변경(보증금 지급일을 -23일함)
         if(entity.getDepositReturnDate().isAfter(LocalDate.now())){
-
             participationService.setDateToReturnDeposit(entity,
                 entity.getDepositReturnDate().minusDays(23));
 
@@ -223,24 +223,12 @@ public class ParticipationManagementService {
                     ,DepositStatus.PAID),
                 List.of(RatingStatus.RATED)
             );
-
-
         }
-
-
     }
 
-    // 6. 여행을 왼료한 후에 보증금이 반환됨
-    public void returnDepositAfterTravelFinished(Long postId,
-        String userId) {
-
-        // 매일 보증금 반환시점을 확인하고 보증금 반환을 확인하는 logic 추가
-
-        // 식별된 entity를 호출해옴
-        ParticipationEntity participationEntity = participationService
-            .getParticipationEntityByPostIdAndUserId(postId, userId);
-
-
+    // 6 여행을 왼료한 후에 보증금이 반환됨
+    @Transactional
+    public void returnDepositAfterTravelFinished(ParticipationEntity participationEntity) {
 
         // 보증금 반환 상태를 검증 후 상태 변환
         participationService.checkAndChangeStatusParticipation(

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -143,7 +143,7 @@ public class ParticipationManagementService {
         // 매일 게시글의 여행완료 시점을 확인 로직 추가
 
         List<ParticipationEntity> participationEntities
-            = participationService.findParticipationToCompleteByNow();
+            = participationService.getParticipationOfPostIdOnDeadLine();
 
         // 참여의 상태를 검증하고 변경
         for (ParticipationEntity participationEntity : participationEntities) {

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -48,6 +48,14 @@ public class ParticipationManagementService {
 
     private final ParticipationService participationService;
     private final PayApi payApi;
+
+
+    private final int DEPOSIT_RETURN_DATE_DEFAULT = 30;
+    private final int DEPOSIT_RETURN_DATE_SHORTENED_IF_RATED = 23;
+    private final int NEXT_DAY = 1;
+
+
+
     // 1. 여행을 참가 ; 여행참가 ~ 지불까지를 하나의 트랜잭션으로 묶기에는 과도하게 길어서 분리.
     // JoinReady 상태 임시저장 -> client 에서 결제준비요청 -> 결제완료/실패시 서버에 응답
     public ParticipationDto readyParticipation(Long postId, String userId,
@@ -64,13 +72,11 @@ public class ParticipationManagementService {
 
         // participation, userId를 통해서 participationEntity호출
         ParticipationEntity participationEntity = participationService
-            .validateParticipationUserId(participationId, userId);
+            .getParticipationByIdAndValidateUserId(participationId, userId);
 
         // fail에 따른 상태검증 및 상태변경
         participationService.checkAndChangeStatusParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN_READY,DepositStatus.UNPAID),
-            List.of(ParticipationStatus.JOIN_FAILED));
+            participationEntity, ParticipationEntity.beforePayStatuses,ParticipationEntity.afterPayFailStatuses);
 
         participationService.saveParticipation(participationEntity);
     }
@@ -80,31 +86,28 @@ public class ParticipationManagementService {
 
         // participation, userId를 통해서 participationEntity호출
         ParticipationEntity participationEntity = participationService
-            .validateParticipationUserId(participationId, userId);
+            .getParticipationByIdAndValidateUserId(participationId, userId);
 
         // confirm에 따른 상태 검증 및 변경
         participationService.checkAndChangeStatusParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN_READY,DepositStatus.UNPAID),
-            List.of(ParticipationStatus.JOIN, DepositStatus.PAID));
+            participationEntity, ParticipationEntity.beforePayStatuses, ParticipationEntity.afterPaySuccessStatuses);
 
         participationService.saveParticipation(participationEntity);
 
     }
 
     //2. 여행을 투표를 통해서 취소, 투표완료시 해당 메소드 호출
+    @Transactional
     public void unjoinParticipationWithDepositReturned(Long postId,
         String userId) {
 
         // postId, userId를 통해서 participationEntity호출
         ParticipationEntity participationEntity = participationService
-            .getParticipationEntityByPostIdAndUserId(postId, userId);
+            .getParticipationByPostIdAndUserId(postId, userId);
 
         // 상태를 검증하고 변환
         participationService.checkAndChangeStatusParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN,DepositStatus.PAID),
-            List.of(ParticipationStatus.JOIN_CANCEL, DepositStatus.RETURNED));
+            participationEntity,ParticipationEntity.afterPaySuccessStatuses,ParticipationEntity.afterVotingStatuses);
 
         // pay모듈에 취소요청
         payApi.payDepositRefund(participationEntity.getParticipationId(),participationEntity.getUserId());
@@ -123,13 +126,11 @@ public class ParticipationManagementService {
 
         // postId, userId를 통해서 participationEntity호출
         ParticipationEntity participationEntity = participationService
-            .getParticipationEntityByPostIdAndUserId(postId, userId);
+            .getParticipationByPostIdAndUserId(postId, userId);
 
         // 상태를 검증하고 변환
         participationService.checkAndChangeStatusParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN, DepositStatus.PAID),
-            List.of(ParticipationStatus.JOIN_CANCEL, DepositStatus.FORFEITED));
+            participationEntity,ParticipationEntity.afterPaySuccessStatuses,ParticipationEntity.afterCancelStatuses);
 
         participationService.saveParticipation(participationEntity);
 
@@ -151,17 +152,18 @@ public class ParticipationManagementService {
 
             participationService.checkAndChangeStatusParticipation(
                 participationEntity,
-                List.of(ParticipationStatus.JOIN),
-                List.of(ParticipationStatus.TRAVEL_FINISHED));
+                ParticipationEntity.afterPaySuccessStatuses,
+                ParticipationEntity.afterTravelFinishStatusesUnRated);
 
             // 보증금 반환일자를 확정
             participationService.setDateToReturnDeposit(participationEntity,
-                LocalDate.now().plusDays(30));
+                LocalDate.now().plusDays(DEPOSIT_RETURN_DATE_DEFAULT));
         }
 
         participationService.saveParticipations(participationEntities);
 
     }
+
 
 
     // 5. 여행을 왼료한 후에 평점을 매김
@@ -178,7 +180,7 @@ public class ParticipationManagementService {
     public void giveRatingParticipation(Long postId, String userId) {
 
         ParticipationEntity entity = participationService
-            .getParticipationEntityByPostIdAndUserId(postId, userId);
+            .getParticipationByPostIdAndUserId(postId, userId);
 
         // 보증금 일자가 정해지지 않았다면 여행이 미완료된 것으로 간주하여 fail
         if(entity.getDepositReturnDate()==null){
@@ -186,11 +188,12 @@ public class ParticipationManagementService {
         }
         //5.1 보증금 기본 반환일이나 그 이후에 평가한 경우, 평점상태만 변경
 
-        if(LocalDate.now().isAfter(entity.getDepositReturnDate().minusDays(1))){
+        if(LocalDate.now().isAfter(entity.getDepositReturnDate().minusDays(
+            NEXT_DAY))){
             participationService.checkAndChangeStatusParticipation(
                 entity,
-                // 자정에 평가하는 문제때문에 우선 deposit 상태는 검증 x
-                List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED),
+                // 자정에 평가하는 문제때문에 우선 deposit 상태는 우선 검증 x
+                ParticipationEntity.afterTravelFinishStatusesUnRated,
                 List.of(RatingStatus.RATED)
             );
         }
@@ -198,30 +201,28 @@ public class ParticipationManagementService {
         //5.2 평점을 여행완료 후 7일이거나 그 이후 그리고 30일이전에 매긴 경우, 다음날을 보증금 지급일 변경 ? 확인필요
 
         if(LocalDate.now().isBefore(entity.getDepositReturnDate())
-        &&LocalDate.now().isAfter(entity.getDepositReturnDate().minusDays(23))){
+        &&LocalDate.now().isAfter(entity.getDepositReturnDate().minusDays(DEPOSIT_RETURN_DATE_SHORTENED_IF_RATED))){
 
             // 보증금 반환일자를 다음날로 설정
             participationService.setDateToReturnDeposit(entity,
-                LocalDate.now().plusDays(1));
+                LocalDate.now().plusDays(NEXT_DAY));
 
             participationService.checkAndChangeStatusParticipation(
                 entity,
-                List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED,
-                    DepositStatus.PAID),
-                List.of(RatingStatus.RATED)
+                ParticipationEntity.afterTravelFinishStatusesUnRated,
+                ParticipationEntity.afterTravelFinishStatusesRated
             );
         }
 
         //5.3 평점을 여행완료 후 7일 전에 매긴 경우, 보증금 지급일을 여행완료 후 7일후로 변경(보증금 지급일을 -23일함)
         if(entity.getDepositReturnDate().isAfter(LocalDate.now())){
             participationService.setDateToReturnDeposit(entity,
-                entity.getDepositReturnDate().minusDays(23));
+                entity.getDepositReturnDate().minusDays(DEPOSIT_RETURN_DATE_SHORTENED_IF_RATED));
 
             participationService.checkAndChangeStatusParticipation(
                 entity,
-                List.of(ParticipationStatus.TRAVEL_FINISHED, RatingStatus.NOT_RATED
-                    ,DepositStatus.PAID),
-                List.of(RatingStatus.RATED)
+                ParticipationEntity.afterTravelFinishStatusesUnRated,
+                ParticipationEntity.afterTravelFinishStatusesRated
             );
         }
     }
@@ -233,8 +234,8 @@ public class ParticipationManagementService {
         // 보증금 반환 상태를 검증 후 상태 변환
         participationService.checkAndChangeStatusParticipation(
             participationEntity,
-            List.of(ParticipationStatus.TRAVEL_FINISHED, DepositStatus.PAID),
-            List.of( DepositStatus.RETURNED)
+            ParticipationEntity.afterTravelFinishStatusesExcludeRating,
+            ParticipationEntity.afterDepositReturnedExcludeRating
         );
 
         // 배당금 반환 API 호출

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 
@@ -224,11 +223,6 @@ public class ParticipationService {
         return participationRepository.findByPostEntityPostIdAndUserId(
             postId, userId).orElseThrow(
             () -> new CustomException(ErrorCode.PARTICIPATION_NOT_FOUND));
-
-
-
-
-
     }
 
 
@@ -244,6 +238,8 @@ public class ParticipationService {
         return participationEntities.stream().map(ResponseParticipationsDto::fromEntity)
             .toList();
     }
+
+
 
 
     //--------------------------- 데이터 count 메소드 ---------------------------//
@@ -300,5 +296,21 @@ public class ParticipationService {
         }
 
         return true;
+    }
+
+    public List<ParticipationEntity> findParticipationToCompleteByNow(){
+
+        List<PostEntity> postEntities = postRepository.findAllPostByDeadlineAndStatus(
+            LocalDate.now(), PostStatus.RECRUITMENT_COMPLETED);
+
+        List<ParticipationEntity> allByPostEntityIn = participationRepository.findAllByPostEntityIn(
+            postEntities);
+
+        return allByPostEntityIn;
+    }
+
+
+    public void saveParticipations(List<ParticipationEntity> participationEntities) {
+        participationRepository.saveAll(participationEntities);
     }
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -321,4 +321,8 @@ public class ParticipationService {
     public void saveParticipation(ParticipationEntity participationEntity) {
         participationRepository.save(participationEntity);
     }
+
+    public List<ParticipationEntity> getParticipationsByDepositReturnDate() {
+       return participationRepository.findAllByDepositReturnDate(LocalDate.now());
+    }
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -73,7 +73,7 @@ public class ParticipationService {
 
         //  유저의 참여중인 정보를 호출
         List<ParticipationDto> participations =
-            this.findParticipationsJoinAndJoinReadyByUserId(userId);
+            this.getParticipationsByStatusOfJoinAndJoinReadyAndByUserId(userId);
 
 
         // 1.1 유저는 최대 두개까지만 참여가능
@@ -209,36 +209,6 @@ public class ParticipationService {
 
     }
 
-    public void saveParticipation(ParticipationEntity participationEntity) {
-        participationRepository.save(participationEntity);
-    }
-
-    //--------------------------- 데이터 load 메소드 ---------------------------//
-
-    // 현재 개별인원 엔티티 반환
-    public ParticipationEntity getParticipationEntityByPostIdAndUserId(
-        Long postId, String userId) {
-        log.info("participation getParticipationEntityByPostIdAndUserId");
-
-        return participationRepository.findByPostEntityPostIdAndUserId(
-            postId, userId).orElseThrow(
-            () -> new CustomException(ErrorCode.PARTICIPATION_NOT_FOUND));
-    }
-
-
-    // 현재 여행을 참여하고 있는 복수 인원리스트 반환
-    public List<ResponseParticipationsDto> getParticipationsDtosStatusOfJoin(
-        Long postId) {
-        log.info("participation getParticipationsStatusOfJoinAndJoin");
-
-        List<ParticipationEntity> participationEntities
-            = participationRepository.findAllByPostEntityPostIdAndParticipationStatusIn(
-            postId, List.of(ParticipationStatus.JOIN,ParticipationStatus.JOIN_READY));
-
-        return participationEntities.stream().map(ResponseParticipationsDto::fromEntity)
-            .toList();
-    }
-
 
 
 
@@ -249,14 +219,7 @@ public class ParticipationService {
         return participationRepository.countByUserIdAndParticipationStatusIn(
             userId, List.of(ParticipationStatus.TRAVEL_FINISHED));
     }
-    public List<ParticipationDto> findParticipationsJoinAndJoinReadyByUserId(String userId) {
-        List<ParticipationEntity> participationEntities = participationRepository.findAllByUserIdAndParticipationStatusIn(
-            userId,
-            List.of(ParticipationStatus.JOIN, ParticipationStatus.JOIN_READY));
 
-        return participationEntities.stream().map(ParticipationDto::fromEntity).toList();
-
-    }
     private int countParticipationsJoinAndJoinReadyByPostId(long postId) {
         return participationRepository.countByPostEntityPostIdAndParticipationStatusIn(
             postId,
@@ -298,7 +261,44 @@ public class ParticipationService {
         return true;
     }
 
-    public List<ParticipationEntity> findParticipationToCompleteByNow(){
+    //--------------------------- 데이터 load 메소드 ---------------------------//
+
+    // 현재 개별인원 엔티티 반환
+    public ParticipationEntity getParticipationEntityByPostIdAndUserId(
+        Long postId, String userId) {
+        log.info("participation getParticipationEntityByPostIdAndUserId");
+
+        return participationRepository.findByPostEntityPostIdAndUserId(
+            postId, userId).orElseThrow(
+            () -> new CustomException(ErrorCode.PARTICIPATION_NOT_FOUND));
+    }
+
+
+    // 현재 여행을 참여하고 있는 복수 인원리스트 반환
+    public List<ResponseParticipationsDto> getParticipationsDtosByPostIdAndStatusOfJoin(
+        Long postId) {
+        log.info("participation getParticipationsStatusOfJoinAndJoin");
+
+        List<ParticipationEntity> participationEntities
+            = participationRepository.findAllByPostEntityPostIdAndParticipationStatusIn(
+            postId, List.of(ParticipationStatus.JOIN,ParticipationStatus.JOIN_READY));
+
+        return participationEntities.stream().map(ResponseParticipationsDto::fromEntity)
+            .toList();
+    }
+
+
+
+    public List<ParticipationDto> getParticipationsByStatusOfJoinAndJoinReadyAndByUserId(String userId) {
+        List<ParticipationEntity> participationEntities = participationRepository.findAllByUserIdAndParticipationStatusIn(
+            userId,
+            List.of(ParticipationStatus.JOIN, ParticipationStatus.JOIN_READY));
+
+        return participationEntities.stream().map(ParticipationDto::fromEntity).toList();
+
+    }
+
+    public List<ParticipationEntity> getParticipationOfPostIdOnDeadLine(){
 
         List<PostEntity> postEntities = postRepository.findAllPostByDeadlineAndStatus(
             LocalDate.now(), PostStatus.RECRUITMENT_COMPLETED);
@@ -310,7 +310,15 @@ public class ParticipationService {
     }
 
 
+
+
     public void saveParticipations(List<ParticipationEntity> participationEntities) {
         participationRepository.saveAll(participationEntities);
+    }
+
+
+
+    public void saveParticipation(ParticipationEntity participationEntity) {
+        participationRepository.save(participationEntity);
     }
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ScheduleTask.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ScheduleTask.java
@@ -1,20 +1,41 @@
 package com.zerobase.travel.service;
 
+import com.zerobase.travel.entity.ParticipationEntity;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class ScheduleTask {
 
     private final ParticipationManagementService participationManagementService;
+    private final ParticipationService participationService;
 
 
-    @Scheduled(cron= "0 0 1 * * *")
-    public void performParticipationTravelFinish(){
+    @Scheduled(cron = "0 0 1 * * *")
+    public void performParticipationTravelFinish() {
         participationManagementService.travelFinishedParticipations();
     }
 
 
-}
+    // 보증금을 반환할 대상을 호출하고, 보증금 반환로직을 실행한다.
+    @Scheduled(cron = "0 0 1 * * *")
+    public void performParticipationDepositReturn() {
+            List<ParticipationEntity> participationEntities = participationService.getParticipationsByDepositReturnDate();
+            for (ParticipationEntity participationEntity : participationEntities) {
+                try {
+                    participationManagementService.returnDepositAfterTravelFinished(
+                        participationEntity);
+                }catch (Exception exception){
+                    log.error("Error processing deposit return for participation ID: {}", participationEntity.getParticipationId(), exception);
+                }
+            }
+
+        }
+
+
+    }

--- a/travel/src/main/java/com/zerobase/travel/service/ScheduleTask.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ScheduleTask.java
@@ -1,0 +1,20 @@
+package com.zerobase.travel.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleTask {
+
+    private final ParticipationManagementService participationManagementService;
+
+
+    @Scheduled(cron= "0 0 1 * * *")
+    public void performParticipationTravelFinish(){
+        participationManagementService.travelFinishedParticipations();
+    }
+
+
+}

--- a/travel/src/test/java/com/zerobase/travel/service/ParticipationManagementServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/ParticipationManagementServiceTest.java
@@ -139,8 +139,6 @@ class ParticipationManagementServiceTest {
 
         when(participationService.getParticipationEntityByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
 
-        // When
-        participationManagementService.returnDepositAfterTravelFinished(POST_ID, USER_ID);
 
         // Then
         verify(participationService).checkAndChangeStatusParticipation(

--- a/travel/src/test/java/com/zerobase/travel/service/ParticipationManagementServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/ParticipationManagementServiceTest.java
@@ -60,7 +60,7 @@ class ParticipationManagementServiceTest {
     void failedPaymentParticipation_shouldUpdateStatusToJoinFailed() {
         // Given
         ParticipationEntity participationEntity = new ParticipationEntity();
-        when(participationService.validateParticipationUserId(PARTICIPATION_ID, USER_ID)).thenReturn(participationEntity);
+        when(participationService.getParticipationByIdAndValidateUserId(PARTICIPATION_ID, USER_ID)).thenReturn(participationEntity);
 
         // When
         participationManagementService.failedPaymentParticipation(PARTICIPATION_ID, USER_ID);
@@ -77,7 +77,7 @@ class ParticipationManagementServiceTest {
     void successPaymentParticipation_shouldUpdateStatusToJoinAndPaid() {
         // Given
         ParticipationEntity participationEntity = new ParticipationEntity();
-        when(participationService.validateParticipationUserId(PARTICIPATION_ID, USER_ID)).thenReturn(participationEntity);
+        when(participationService.getParticipationByIdAndValidateUserId(PARTICIPATION_ID, USER_ID)).thenReturn(participationEntity);
 
         // When
         participationManagementService.successPaymentParticipation(PARTICIPATION_ID, USER_ID);
@@ -95,7 +95,7 @@ class ParticipationManagementServiceTest {
         // Given mock participationservice
 
 
-        when(participationService.getParticipationEntityByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
+        when(participationService.getParticipationByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
 
 
         // When
@@ -115,7 +115,7 @@ class ParticipationManagementServiceTest {
     void unjoinParticipationWithDepositForfeited_shouldUpdateStatusToJoinCancelAndForfeited() {
         // Given
         ParticipationEntity participationEntity = new ParticipationEntity();
-        when(participationService.getParticipationEntityByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
+        when(participationService.getParticipationByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
 
         // When
         participationManagementService.unjoinParticipationWithDepositForfeited(POST_ID, USER_ID);
@@ -137,7 +137,7 @@ class ParticipationManagementServiceTest {
     void returnDepositAfterTravelFinished_shouldUpdateStatusToReturnedAndCallPayApi() {
         // Given
 
-        when(participationService.getParticipationEntityByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
+        when(participationService.getParticipationByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
 
 
         // Then

--- a/travel/src/test/java/com/zerobase/travel/service/ParticipationManagementServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/ParticipationManagementServiceTest.java
@@ -1,20 +1,14 @@
 package com.zerobase.travel.service;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.zerobase.travel.api.PayApi;
-import com.zerobase.travel.communities.type.CustomException;
-import com.zerobase.travel.communities.type.ErrorCode;
-import com.zerobase.travel.dto.ParticipationDto;
 import com.zerobase.travel.entity.ParticipationEntity;
 import com.zerobase.travel.type.DepositStatus;
 import com.zerobase.travel.type.ParticipationStatus;
 import com.zerobase.travel.type.RatingStatus;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -136,20 +130,7 @@ class ParticipationManagementServiceTest {
 
     @Test
     void travelFinishedParticipation_shouldUpdateStatusToTravelFinished() {
-        // Given
-        ParticipationEntity participationEntity = new ParticipationEntity();
-        when(participationService.getParticipationEntityByPostIdAndUserId(POST_ID, USER_ID)).thenReturn(participationEntity);
-
-        // When
-        participationManagementService.travelFinishedParticipation(POST_ID, USER_ID);
-
-        // Then
-        verify(participationService).checkAndChangeStatusParticipation(
-            participationEntity,
-            List.of(ParticipationStatus.JOIN),
-            List.of(ParticipationStatus.TRAVEL_FINISHED));
-        verify(participationService).setDateToReturnDeposit(eq(participationEntity), any(LocalDate.class));
-        verify(participationService).saveParticipation(participationEntity);
+        // Given;
     }
 
     @Test


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
 participation status 변환 로직 helper method 도입을 통한 간결화

## 🔑 PR에서 핵심적으로 변경된 사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
service logic 내에 enum의 hardcoding을 통해서 participation status 변경

**TO-BE**
Participation Entity 내에 각 participation의 단계별 static field도입
Participation Entity 내에 participatoin의 status를 검증하고 변경하는 helper method 도입

