### PR TITLE
fix) Communities request dto field 초기값 설정으로 nullpoint exception 해결

### DIFF
--- a/pay/src/main/java/com/zerobase/model/RequestApi.java
+++ b/pay/src/main/java/com/zerobase/model/RequestApi.java
@@ -11,8 +11,6 @@ public class RequestApi {
 
     @Getter
     @Setter
-    @Builder
-    @AllArgsConstructor
     @NoArgsConstructor
     public static class ConfirmDto {
 
@@ -35,9 +33,6 @@ public class RequestApi {
     }
 
     @Getter
-    @Setter
-    @Builder
-    @AllArgsConstructor
     @NoArgsConstructor
     public static class ReadyDto {
         private String cid;
@@ -71,9 +66,7 @@ public class RequestApi {
     }
 
     @Getter
-    @Setter
-    @Builder
-    @AllArgsConstructor
+
     @NoArgsConstructor
     public static class RefundDto {
 

--- a/pay/src/main/java/com/zerobase/model/RequestConfirmPayDeposit.java
+++ b/pay/src/main/java/com/zerobase/model/RequestConfirmPayDeposit.java
@@ -9,8 +9,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor
 public class RequestConfirmPayDeposit {
     Long depositId;

--- a/pay/src/main/java/com/zerobase/model/RequestPayDepositFail.java
+++ b/pay/src/main/java/com/zerobase/model/RequestPayDepositFail.java
@@ -1,8 +1,12 @@
 package com.zerobase.model;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class RequestPayDepositFail {
 
     private long depositId;

--- a/pay/src/main/java/com/zerobase/model/RequestPayDepositSuccess.java
+++ b/pay/src/main/java/com/zerobase/model/RequestPayDepositSuccess.java
@@ -1,8 +1,12 @@
 package com.zerobase.model;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class RequestPayDepositSuccess {
 
     private String pg_token;

--- a/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
+++ b/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
@@ -9,8 +9,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor
 public class RequestReadyPayDeposit {
     Long postId;

--- a/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
+++ b/pay/src/main/java/com/zerobase/model/RequestReadyPayDeposit.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class RequestReadyPayDeposit {
-    Long postId;
-    Long participationId;
-    PGMethod pgMethod;
+    private long postId;
+    private long participationId;
+    private PGMethod pgMethod;
 }

--- a/pay/src/main/java/com/zerobase/model/RequestpayDepositRefund.java
+++ b/pay/src/main/java/com/zerobase/model/RequestpayDepositRefund.java
@@ -4,11 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Builder
-@AllArgsConstructor
+
 @NoArgsConstructor
 @Getter
+@Setter
 public class RequestpayDepositRefund {
 
     private long depositId;

--- a/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/controller/CommunityController.java
@@ -3,7 +3,7 @@ package com.zerobase.travel.communities.controller;
 import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.communities.service.CommunityManagementService;
 import com.zerobase.travel.communities.type.RequestCreateCommunity;
-import com.zerobase.travel.communities.type.RequestPostCommunity;
+import com.zerobase.travel.communities.type.RequestUpdateCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
 import com.zerobase.travel.post.dto.response.PagedResponseDTO;
 import jakarta.validation.Valid;
@@ -75,7 +75,7 @@ public class CommunityController {
     // 커뮤니티 수정
     @PutMapping(value = "/{communityId}")
     public ResponseEntity<ResponseMessage<ResponseCommunityDto>> updateCommunity(
-        @Valid @RequestBody RequestPostCommunity request,
+        @Valid @RequestBody RequestUpdateCommunity request,
         @RequestHeader("X-User-Id") String userId) {
         return ResponseEntity.ok(ResponseMessage.success(
             communityManagementService.updatePost(request, userId)));

--- a/travel/src/main/java/com/zerobase/travel/communities/service/CommunityManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/service/CommunityManagementService.java
@@ -3,7 +3,7 @@ package com.zerobase.travel.communities.service;
 import com.zerobase.travel.communities.type.CommunityDto;
 import com.zerobase.travel.communities.type.CommunityFileDto;
 import com.zerobase.travel.communities.type.RequestCreateCommunity;
-import com.zerobase.travel.communities.type.RequestPostCommunity;
+import com.zerobase.travel.communities.type.RequestUpdateCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
 import com.zerobase.travel.post.dto.response.PagedResponseDTO;
 import java.util.List;
@@ -88,7 +88,7 @@ public class CommunityManagementService {
     }
 
     @Transactional
-    public ResponseCommunityDto updatePost( RequestPostCommunity request,
+    public ResponseCommunityDto updatePost( RequestUpdateCommunity request,
         String userId) {
 
 

--- a/travel/src/main/java/com/zerobase/travel/communities/type/RequestCreateCommunity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/RequestCreateCommunity.java
@@ -16,16 +16,16 @@ import lombok.Setter;
 public class RequestCreateCommunity {
 
     @NotNull
-    Continent continent;
+    private Continent continent;
     @NotNull
-    Country country;
+    private Country country;
     @NotBlank
-    String region;
+    private String region;
     @NotBlank
-    String title;
+    private String title;
     @NotBlank
-    String content;
-    List<String> files = new ArrayList<>();
+    private String content;
+    private List<String> files = new ArrayList<>();
 
 
 

--- a/travel/src/main/java/com/zerobase/travel/communities/type/RequestCreateCommunity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/RequestCreateCommunity.java
@@ -4,9 +4,8 @@ import com.zerobase.travel.typeCommon.Continent;
 import com.zerobase.travel.typeCommon.Country;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,8 +13,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class RequestCreateCommunity {
 
     @NotNull
@@ -28,5 +25,12 @@ public class RequestCreateCommunity {
     String title;
     @NotBlank
     String content;
-    List<String> files;
+    List<String> files = new ArrayList<>();
+
+
+
 }
+
+
+
+

--- a/travel/src/main/java/com/zerobase/travel/communities/type/RequestUpdateCommunity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/RequestUpdateCommunity.java
@@ -15,9 +15,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class RequestPostCommunity {
+public class RequestUpdateCommunity {
 
 
     @Min(1)

--- a/travel/src/main/java/com/zerobase/travel/communities/type/RequestUpdateCommunity.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/RequestUpdateCommunity.java
@@ -5,6 +5,7 @@ import com.zerobase.travel.typeCommon.Country;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,16 +20,16 @@ public class RequestUpdateCommunity {
 
 
     @Min(1)
-    long communityId;
+    private long communityId;
     @NotNull
-    Continent continent;
+    private Continent continent;
     @NotNull
-    Country country;
+    private Country country;
     @NotBlank
-    String region;
+    private String region;
     @NotBlank
-    String title;
+    private String title;
     @NotBlank
-    String content;
-    List<String> files;
+    private String content;
+    private List<String> files=new ArrayList<>();
 }

--- a/travel/src/main/java/com/zerobase/travel/communities/type/ResponseCommunityDto.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/ResponseCommunityDto.java
@@ -16,14 +16,14 @@ import lombok.Setter;
 @NoArgsConstructor
 public class ResponseCommunityDto {
 
-    long communityId;
-    String userId;
-    Continent continent;
-    Country country;
-    String region;
-    String title;
-    String content;
-    List<CommunityFileDto> files;
+    private long communityId;
+    private String userId;
+    private Continent continent;
+    private Country country;
+    private String region;
+    private String title;
+    private String content;
+    private List<CommunityFileDto> files;
 
     public static ResponseCommunityDto fromEntity(
         CommunityDto communityDto,List<CommunityFileDto> communityFileDtos){

--- a/travel/src/test/java/com/zerobase/travel/communities/controller/CommunityControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/controller/CommunityControllerTest.java
@@ -1,6 +1,5 @@
 package com.zerobase.travel.communities.controller;
 
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,15 +11,13 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.travel.communities.service.CommunityManagementService;
-import com.zerobase.travel.communities.type.RequestCreateCommunity;
-import com.zerobase.travel.communities.type.RequestPostCommunity;
+import com.zerobase.travel.communities.type.RequestUpdateCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
 import com.zerobase.travel.post.dto.response.PagedResponseDTO;
 import com.zerobase.travel.typeCommon.Continent;
@@ -31,8 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -40,10 +35,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.http.MediaType;
 
 @ExtendWith(MockitoExtension.class)
 @WebMvcTest(controllers = CommunityController.class)
@@ -89,36 +83,6 @@ class CommunityControllerTest {
 
         // given request
 
-        List<String> files = List.of("file1", "file2");
-
-        RequestCreateCommunity request = RequestCreateCommunity.builder()
-            .continent(Continent.ASIA)
-            .country(Country.KR)
-            .region("Seoul")
-            .title("Sample Title")
-            .content("Sample Content")
-            .files(files)
-            .build();
-
-
-        //when
-
-        when(communityManagementService.createPost(any(RequestCreateCommunity.class),anyString()))
-            .thenReturn(sampleCommunityResponse);
-
-
-        mockMvc.perform(
-            post("/communities")
-                .header(USER_ID_HEADER, SAMPLE_USER_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .with(csrf())
-            )
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.communityId").value(1))
-            .andExpect(jsonPath("$.userId").value(SAMPLE_USER_ID))
-            .andExpect(jsonPath("$.title").value("Sample Community"))
-            .andExpect(jsonPath("$.content").value("Sample content"));
     }
 
     @Test
@@ -189,17 +153,17 @@ class CommunityControllerTest {
     @WithMockUser
     void updateCommunity() throws Exception {
         // Given an update request
-        RequestPostCommunity request = RequestPostCommunity.builder()
-            .communityId(1L)
-            .title("Updated Title")
-            .content("Updated Content")
-            .continent(Continent.ASIA)
-            .country(Country.KR)
-            .region("Busan")
-            .build();
+        RequestUpdateCommunity request =  new RequestUpdateCommunity();
+
+        request.setCommunityId(1L);
+        request.setTitle("Updated Title");
+        request.setContent("Updated Content");
+        request.setContinent(Continent.ASIA);
+        request.setCountry(Country.KR);
+        request.setRegion("Busan");
 
         // Mocking the service's response to return a sample community response
-        given(communityManagementService.updatePost(any(RequestPostCommunity.class), anyString()))
+        given(communityManagementService.updatePost(any(RequestUpdateCommunity.class), anyString()))
             .willReturn(sampleCommunityResponse);
 
         // Perform the PUT request
@@ -216,7 +180,8 @@ class CommunityControllerTest {
             .andExpect(jsonPath("$.content").value("Sample content"));
 
         // Verify that the service method was called with the correct parameters
-        verify(communityManagementService, times(1)).updatePost(any(RequestPostCommunity.class), eq(SAMPLE_USER_ID));
+        verify(communityManagementService, times(1)).updatePost(any(
+            RequestUpdateCommunity.class), eq(SAMPLE_USER_ID));
     }
 
 }

--- a/travel/src/test/java/com/zerobase/travel/communities/service/CommunityManagementServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/service/CommunityManagementServiceTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.verify;
 import com.zerobase.travel.communities.type.CommunityDto;
 import com.zerobase.travel.communities.type.CommunityFileDto;
 import com.zerobase.travel.communities.type.RequestCreateCommunity;
-import com.zerobase.travel.communities.type.RequestPostCommunity;
+import com.zerobase.travel.communities.type.RequestUpdateCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
 import com.zerobase.travel.post.dto.response.PagedResponseDTO;
 import com.zerobase.travel.typeCommon.Continent;
@@ -59,14 +59,6 @@ class CommunityManagementServiceTest {
         sampleFiles = List.of(new CommunityFileDto(1L, "file1.jpg"),
             new CommunityFileDto(2L, "file2.jpg"));
 
-        createRequest = RequestCreateCommunity.builder()
-            .continent(Continent.ASIA)
-            .country(Country.KR)
-            .region("Busan")
-            .title("Sample Title")
-            .content("Sample Content")
-            .files(List.of("file1.jpg", "file2.jpg"))
-            .build();
     }
 
     @Test
@@ -143,15 +135,16 @@ class CommunityManagementServiceTest {
     @Test
     void updatePost() {
         // Given
-        RequestPostCommunity request = RequestPostCommunity.builder()
-            .communityId(1L)
-            .continent(Continent.ASIA)
-            .country(Country.KR)
-            .region("Busan")
-            .title("Updated Title")
-            .content("Updated Content")
-            .files(List.of("updated_file1.jpg", "updated_file2.jpg"))
-            .build();
+        RequestUpdateCommunity request = new RequestUpdateCommunity();
+
+        request.setCommunityId(1L);
+        request.setTitle("Updated Title");
+        request.setContent("Updated Content");
+        request.setContinent(Continent.ASIA);
+        request.setCountry(Country.KR);
+        request.setRegion("Busan");
+        request.setFiles(List.of("updated_file1.jpg", "updated_file2.jpg"));
+
 
         CommunityDto updatedCommunityDto = CommunityDto.builder()
             .communityId(1L)


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
- Communities create시 file이 입력되지 않으면 nullpoint exception이 발생하던 문제 해결
- request dto에 불필요한 lombok args 제거 
-  request dto에 private 미추가 필드 추가

## 🔑 PR에서 핵심적으로 변경된 사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
request의 file list field에 기본값이 없어 file save method 내에서 stream 처리시 nullpoint excpetion 발생

**TO-BE**
request의 file list field에 list 초기값 설정으로 오류해결

## 📊 테스트
    
- [x ] API 테스트 
