### PR TITLE
fix) community delete기능시, findByuserId로 찾던 기능을 findBycommunityId로 변경

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/communities/service/CommunityService.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/service/CommunityService.java
@@ -64,8 +64,13 @@ public class CommunityService {
 
     public void deletePost(long communityId, String userId) {
 
-        communityRepository.findByUserId(userId).orElseThrow(()
-            -> new CustomException(ErrorCode.USER_UNAUTHORIZED_REQUEST));
+        CommunityEntity communityEntity = communityRepository.findById(
+            communityId).orElseThrow(()
+            -> new CustomException(ErrorCode.COMMUNITY_NON_EXISTENT));
+
+        if(!communityEntity.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.USER_UNAUTHORIZED_REQUEST);
+        }
 
         communityRepository.deleteByCommunityId(communityId);
     }


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
 community delete기능시, findByuserId로 찾던 기능을 findBycommunityId로 변경
- repo에서 entity 타입으로 반환하나, db에서 검색된 레코드는 복수건으로 error발생문제해결

## 📊 테스트   
- [ x] API 테스트 