### PR TITLE
Fix/refund deposit

### DIFF
--- a/pay/src/main/java/com/zerobase/api/KakaopayApi.java
+++ b/pay/src/main/java/com/zerobase/api/KakaopayApi.java
@@ -7,7 +7,6 @@ import com.zerobase.model.RequestApi;
 import com.zerobase.model.RequestApi.ConfirmDto;
 import com.zerobase.model.RequestApi.RefundDto;
 import com.zerobase.model.ResponseApi;
-import com.zerobase.model.ResponseApi.PayReadyApiDto;
 import com.zerobase.model.ResponseApi.PayRefundApiDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +45,7 @@ public class KakaopayApi implements ApiInterface {
             .quantity(String.valueOf(constants.QUANTITY))
             .totalAmount(String.valueOf(constants.DEPOSIT_AMOUNT))
             .taxFreeAmount(String.valueOf(constants.TAX_FREE_AMOUNT))
+            .vatAmount(String.valueOf(constants.VAT_AMOUNT))
             .approvalUrl(constants.KAKAO_APPROVAL_URL+"/"+postId+"?depositId="+depositId)
             .cancelUrl(constants.KAKAO_CANCEL_URL+"?depositId="+depositId)
             .failUrl(constants.KAKAO_FAIL_URL+"?depositId="+depositId)
@@ -97,7 +97,7 @@ public class KakaopayApi implements ApiInterface {
     }
 
     public PayRefundApiDto sendPayRefundSign(
-         String tid, Long cancelAmount, Long cancel_tax_free_amount ) {
+         String tid ) {
         log.info("KakaopayApiService payRefundSign");
         // webclient url, header입력
 
@@ -110,8 +110,9 @@ public class KakaopayApi implements ApiInterface {
         RequestApi.RefundDto refundDto = RefundDto.builder()
             .cid(constants.KAKAO_CID)
             .tid(tid)
-            .cancelAmount(String.valueOf(cancelAmount))
-            .cancelTaxFreeAmount(String.valueOf(cancel_tax_free_amount))
+            .cancelAmount(String.valueOf(constants.DEPOSIT_AMOUNT))
+            .cancelTaxFreeAmount(String.valueOf(constants.TAX_FREE_AMOUNT))
+            .cancelVatAmount(String.valueOf(constants.VAT_AMOUNT))
             .build();
         //
         PayRefundApiDto payRefundApiDto = webclient.post()

--- a/pay/src/main/java/com/zerobase/config/Constants.java
+++ b/pay/src/main/java/com/zerobase/config/Constants.java
@@ -35,6 +35,10 @@ public class Constants {
     @Value("${kakaopay.tax-free-amount}")
     public long TAX_FREE_AMOUNT;
 
+    @Value("${kakaopay.vat-amount}")
+    public long VAT_AMOUNT;
+
+
     @Value("${kakaopay.secret-key}")
     public String SECRET_KEY;
 

--- a/pay/src/main/java/com/zerobase/controller/InternalPayController.java
+++ b/pay/src/main/java/com/zerobase/controller/InternalPayController.java
@@ -28,7 +28,7 @@ public class InternalPayController {
     public ResponseEntity<Object> payDepositRefund(
         RequestpayDepositRefund request) {
         log.info(" pay deposit refund sign from client");
-         payManagementService.refundDepositPay(request.getDepositId(), request.getUserId());
+         payManagementService.refundDepositPay(request.getParticipationId(), request.getUserId());
         return ResponseEntity.ok().build();
     }
 

--- a/pay/src/main/java/com/zerobase/controller/InternalPayController.java
+++ b/pay/src/main/java/com/zerobase/controller/InternalPayController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,7 +27,7 @@ public class InternalPayController {
     // client 결제환불시 url 신호받기
     @PutMapping(value = "/deposit/refund")
     public ResponseEntity<Object> payDepositRefund(
-        RequestpayDepositRefund request) {
+        @RequestBody RequestpayDepositRefund request) {
         log.info(" pay deposit refund sign from client");
          payManagementService.refundDepositPay(request.getParticipationId(), request.getUserId());
         return ResponseEntity.ok().build();

--- a/pay/src/main/java/com/zerobase/exception/GlobalExceptionHandler.java
+++ b/pay/src/main/java/com/zerobase/exception/GlobalExceptionHandler.java
@@ -34,6 +34,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleGeneralException(Exception ex) {
+        log.error(ex.getMessage(),ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ResponseMessage.fail(PaymentErrorCode.INTERNAL_SERVER_ERROR));
     }

--- a/pay/src/main/java/com/zerobase/exception/errorCode/PaymentErrorCode.java
+++ b/pay/src/main/java/com/zerobase/exception/errorCode/PaymentErrorCode.java
@@ -8,10 +8,14 @@ import lombok.Getter;
 public enum PaymentErrorCode {
     DEPOSIT_NOT_EXSITING("ERROR-PAYMENT-00001", "존재하지 않는 DEPOSIT ID입니다."),
     PAYMENT_NOT_EXSITING("ERROR-PAYMENT-00002", "존재하지 않는 PAYMENT ID입니다."),
-    DESPOSIT_ALREADY_PAID("ERROR-PAYMENT-00003", "해당 Deposit은 이미 결제완료되었습니다"),
+    DEPOSIT_ALREADY_PAID("ERROR-PAYMENT-00003", "해당 Deposit은 이미 결제완료되었습니다"),
     REQUEST_VALIDATION_ERROR("ERROR-PAYMENT-00004", "Validation Error"),
     INVALID_PARTICIPATION_INFORMATION("ERROR-PAYMENT-00005", "잘못된 참여 정보입니다."),
-    INTERNAL_SERVER_ERROR("ERROR-PAYMENT-00006", "서버 내 에러입니다.");
+    INTERNAL_SERVER_ERROR("ERROR-PAYMENT-00006", "서버 내 에러입니다."),
+    INVALID_DEPOSIT_INFORMATION("ERROR-PAYMENT-00007", "보증금 데이터가 비정상입니다."),
+    INVALID_PAYMENT_INFORMATION("ERROR-PAYMENT-00008", "보증금 데이터가 비정상입니다.");
+
+
 
     private final String errorCode;
     private final String errorMessage;

--- a/pay/src/main/java/com/zerobase/model/RequestApi.java
+++ b/pay/src/main/java/com/zerobase/model/RequestApi.java
@@ -61,6 +61,9 @@ public class RequestApi {
         @JsonProperty("tax_free_amount")
         private String taxFreeAmount;
 
+        @JsonProperty("vat_amount")
+        private String vatAmount;
+
         @JsonProperty("approval_url")
         private  String approvalUrl;
 
@@ -87,6 +90,12 @@ public class RequestApi {
 
         @JsonProperty("cancel_tax_free_amount")
         private String cancelTaxFreeAmount;
+
+        @JsonProperty("cancel_vat_amount")
+        private String cancelVatAmount;
+
+
+
 
 
 

--- a/pay/src/main/java/com/zerobase/model/RequestpayDepositRefund.java
+++ b/pay/src/main/java/com/zerobase/model/RequestpayDepositRefund.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 public class RequestpayDepositRefund {
 
-    private long depositId;
+    private long participationId;
     private String userId;
 
 }

--- a/pay/src/main/java/com/zerobase/model/ResponseApi.java
+++ b/pay/src/main/java/com/zerobase/model/ResponseApi.java
@@ -45,6 +45,16 @@ public class ResponseApi {
         private String tid;
         private String status;
         @JsonProperty("approved_cancel_amount")
-        private String approvedCancelAmount;
+        private CancelAmountDto approvedCancelAmount;
+
+
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        public class CancelAmountDto {
+
+            int total;
+
+        }
     }
 }

--- a/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
+++ b/pay/src/main/java/com/zerobase/repository/PaymentRepository.java
@@ -15,6 +15,10 @@ public interface PaymentRepository extends JpaRepository<PaymentEntity,Long> {
     Optional<PaymentEntity> findByReferentialOrderIdAndPaymentStatus(long referentialOrderId,
         PaymentStatus payCompleted);
 
+    Optional<PaymentEntity> findByReferentialOrderId(long referentialOrderId);
+
+
+
 
     Optional<PaymentEntity> findByUserIdAndPaymentStatus(String usderId, PaymentStatus paymentStatus);
 

--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -7,6 +7,7 @@ import com.zerobase.exception.errorCode.PaymentErrorCode;
 import com.zerobase.model.DepositDto;
 import com.zerobase.model.type.PaymentStatus;
 import com.zerobase.repository.DepositRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -56,7 +57,7 @@ public class DepositService {
         }
 
         if(depositRepository.existsByParticipationIdAndPaymentStatus(participationId,PaymentStatus.PAY_COMPLETED))
-            throw new BizException(PaymentErrorCode.DESPOSIT_ALREADY_PAID);
+            throw new BizException(PaymentErrorCode.DEPOSIT_ALREADY_PAID);
 
 
     }
@@ -87,7 +88,7 @@ public class DepositService {
         return depositEntity;
     }
 
-    public void refundDepositPay(long participationId, String userId) {
+    public DepositEntity SetToRefundDepositPay(long participationId, String userId) {
         DepositEntity depositEntity = depositRepository.findByParticipationId(
             participationId).orElseThrow(() -> new BizException(PaymentErrorCode.DEPOSIT_NOT_EXSITING));
 
@@ -95,14 +96,15 @@ public class DepositService {
 
         depositEntity.setPaymentStatus(PaymentStatus.PAY_REFUNDED);
 
-        depositRepository.save(depositEntity);
+        return depositEntity;
+
     }
 
     private void validateDepositInfo(DepositEntity depositEntity, long participationId, String userId, PaymentStatus paymentStatus) {
 
         if(depositEntity.getParticipationId()!=participationId) throw new BizException(PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
 
-        if(depositEntity.getUserId()!=userId) throw new BizException(PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
+        if(!Objects.equals(depositEntity.getUserId(), userId)) throw new BizException(PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
 
         if(depositEntity.getPaymentStatus()!=paymentStatus) throw new BizException(PaymentErrorCode.INVALID_DEPOSIT_INFORMATION);
 

--- a/pay/src/main/java/com/zerobase/service/DepositService.java
+++ b/pay/src/main/java/com/zerobase/service/DepositService.java
@@ -38,7 +38,7 @@ public class DepositService {
     }
 
 
-    public DepositDto findByParticipationId(Long participationId) {
+    public DepositDto findByParticipationIdAndChangStatus(Long participationId) {
         return DepositDto.fromEntity(depositRepository
             .findByParticipationId(participationId).orElseThrow(
                 () -> new BizException(PaymentErrorCode.DEPOSIT_NOT_EXSITING)));
@@ -68,6 +68,8 @@ public class DepositService {
             .orElseThrow(() -> new BizException(
                 PaymentErrorCode.DEPOSIT_NOT_EXSITING));
 
+
+
         depositEntity.setPaymentStatus(paymentStatus);
 
         return depositEntity;
@@ -83,5 +85,26 @@ public class DepositService {
         depositEntity.setPaymentStatus(paymentStatus);
 
         return depositEntity;
+    }
+
+    public void refundDepositPay(long participationId, String userId) {
+        DepositEntity depositEntity = depositRepository.findByParticipationId(
+            participationId).orElseThrow(() -> new BizException(PaymentErrorCode.DEPOSIT_NOT_EXSITING));
+
+        this.validateDepositInfo(depositEntity,participationId,userId,PaymentStatus.PAY_COMPLETED);
+
+        depositEntity.setPaymentStatus(PaymentStatus.PAY_REFUNDED);
+
+        depositRepository.save(depositEntity);
+    }
+
+    private void validateDepositInfo(DepositEntity depositEntity, long participationId, String userId, PaymentStatus paymentStatus) {
+
+        if(depositEntity.getParticipationId()!=participationId) throw new BizException(PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
+
+        if(depositEntity.getUserId()!=userId) throw new BizException(PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
+
+        if(depositEntity.getPaymentStatus()!=paymentStatus) throw new BizException(PaymentErrorCode.INVALID_DEPOSIT_INFORMATION);
+
     }
 }

--- a/pay/src/main/java/com/zerobase/service/PayManagementService.java
+++ b/pay/src/main/java/com/zerobase/service/PayManagementService.java
@@ -140,23 +140,16 @@ public class PayManagementService {
     client 측에서는 participation을 기준으로 취소요청을 할 것으로 생각됨.
     */
 
+    @Transactional
     public void refundDepositPay(
-        long depositId, String userId) {
+        long participationId, String userId) {
         log.info("refund customer DepositPay");
 
-        DepositEntity depositEntity = depositService.getPaymentInProgressAndchangeStatusByOrderId(
-            depositId, PaymentStatus.PAY_REFUNDED);
+        DepositEntity depositEntity = depositService.SetToRefundDepositPay(participationId, userId);
 
-        PaymentEntity paymentEntity = paymentService.getPaymentsInProgressAndChangeStatusByOrderId(
-            depositId, PaymentStatus.PAY_REFUNDED);
+        PaymentEntity paymentEntity = paymentService.SetToRefundPayment(depositEntity.getDepositId(), userId);
 
-        if(!Objects.equals(depositEntity.getUserId(), userId)
-            || !Objects.equals(paymentEntity.getUserId(), userId)){
-            throw new BizException(PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
-        }
-
-        kakaopayApi.sendPayRefundSign(
-                paymentEntity.getPaykey(), constants.DEPOSIT_AMOUNT, constants.TAX_FREE_AMOUNT);
+        kakaopayApi.sendPayRefundSign(paymentEntity.getPaykey());
 
         paymentService.save(paymentEntity);
         depositService.save(depositEntity);

--- a/pay/src/main/java/com/zerobase/service/PaymentService.java
+++ b/pay/src/main/java/com/zerobase/service/PaymentService.java
@@ -68,20 +68,33 @@ public class PaymentService {
         return paymentEntity;
     }
 
-    public PaymentEntity getPaymentsInPayCompletedByOrderId( String userId,long orderId) {
-        PaymentEntity paymentEntity = paymentRepository.findByReferentialOrderIdAndPaymentStatus(
-            orderId, PaymentStatus.PAY_COMPLETED).orElseThrow(() -> new BizException(
-            PaymentErrorCode.PAYMENT_NOT_EXSITING));
-
-        if(!Objects.equals(paymentEntity.getUserId(), userId)) throw new BizException(
-            PaymentErrorCode.INVALID_PARTICIPATION_INFORMATION);
-
-        return paymentEntity;
-    }
-
 
 
     public void save(PaymentEntity paymentEntity) {
          paymentRepository.save(paymentEntity);
+    }
+
+    public PaymentEntity SetToRefundPayment(long orderId, String userId) {
+        PaymentEntity paymentEntity = paymentRepository.findByReferentialOrderId(orderId)
+            .orElseThrow(() -> new BizException(PaymentErrorCode.PAYMENT_NOT_EXSITING));
+
+        this.validatePayment(paymentEntity,userId,PaymentStatus.PAY_COMPLETED);
+
+
+        return paymentEntity;
+
+
+
+
+    }
+
+    private void validatePayment(PaymentEntity paymentEntity, String userId, PaymentStatus paymentStatus) {
+
+        if(paymentEntity.getPaymentStatus() != paymentStatus)
+            throw new BizException(PaymentErrorCode.INVALID_PAYMENT_INFORMATION);
+
+        if(!Objects.equals(paymentEntity.getUserId(), userId))
+            throw new BizException(PaymentErrorCode.INVALID_PAYMENT_INFORMATION);
+
     }
 }

--- a/pay/src/main/resources-dev/application-dev.yml
+++ b/pay/src/main/resources-dev/application-dev.yml
@@ -43,6 +43,7 @@ kakaopay:
   item-name: "여행참여 보증금"
   quantity: 1
   deposit-amount: 100000
-  tax-free-amount: 9090
+  tax-free-amount: 0
+  vat-amount: 9090
   secret-key: DEVBB2EC55AEA5209485B283C6EAC15502C4B307
 


### PR DESCRIPTION
## 🔑 PR에서 핵심적으로 변경된 사항

1. fix / 결제모듈 Feign Client 파라미터와 Dto 오류 정정

2. fix / 카카오 API DTO 불일치문제 정정

3. feat /  Global Handler 내 에러로그 신규추가

4. feat / 환불관련 메소드 신규생성 및 재개편

**AS-IS**
- Management 메소드 내에 service호출 외에 비즈니스로직/예외처리 로직 존재

**TO-BE**
- Management 메소드 내 비즈니스로직/예외처리 로직 service 내부로 이전

## 📊 테스트
- [x] API 테스트 
