### PR TITLE
Feat/ 참여데이터 비정상 데이터 정리 스케줄러 추가 

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/entity/ParticipationEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/entity/ParticipationEntity.java
@@ -5,6 +5,7 @@ import com.zerobase.travel.type.DepositStatus;
 import com.zerobase.travel.type.ParticipationStatus;
 import com.zerobase.travel.type.RatingStatus;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -23,6 +24,7 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.annotation.Transient;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Entity
@@ -31,6 +33,8 @@ import org.springframework.data.annotation.Transient;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+
 public class ParticipationEntity {
 
     @Id

--- a/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
+++ b/travel/src/main/java/com/zerobase/travel/repository/ParticipationRepository.java
@@ -4,6 +4,7 @@ import com.zerobase.travel.entity.ParticipationEntity;
 import com.zerobase.travel.post.entity.PostEntity;
 import com.zerobase.travel.type.ParticipationStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,4 +33,6 @@ public interface ParticipationRepository extends JpaRepository<ParticipationEnti
     List<ParticipationEntity> findAllByPostEntityIn(List<PostEntity> postEntities);
 
     List<ParticipationEntity> findAllByDepositReturnDate(LocalDate now);
+
+    List<ParticipationEntity> findAllByParticipationStatusAndCreatedAtBefore(ParticipationStatus participationStatus, LocalDateTime localDateTime);
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -84,7 +84,7 @@ public class ParticipationManagementService {
         participationService.saveParticipation(participationEntity);
     }
 
-    // 1.2 여행 참가를 눌러서 결재 완료 혹은 결제실패 처리가 정상처리가 된 경우
+    // 1.2 여행 참가를 눌러서 결재 완료 정상처리가 된 경우
     @Transactional
     public void successPaymentParticipation(long participationId,
         String userId) {

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationScheduleTask.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationScheduleTask.java
@@ -1,6 +1,8 @@
 package com.zerobase.travel.service;
 
+import com.zerobase.travel.dto.ParticipationDto;
 import com.zerobase.travel.entity.ParticipationEntity;
+import com.zerobase.travel.type.ParticipationStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class ScheduleTask {
+public class ParticipationScheduleTask {
 
     private final ParticipationManagementService participationManagementService;
     private final ParticipationService participationService;
@@ -19,6 +21,17 @@ public class ScheduleTask {
     @Scheduled(cron = "0 0 1 * * *")
     public void performParticipationTravelFinish() {
         participationManagementService.travelFinishedParticipations();
+    }
+
+    // 매시간 정각마다 JoinReady인 상태의 Participation이 24시간이 지나면 정리진행함.
+    @Scheduled(cron = "0 0 * * * *")
+    public void clearParticipationJoinReady() {
+        List<ParticipationDto> participationDtos
+            = participationService.getParticipationsByJoinReadyFor24Hours();
+
+        participationDtos.stream()
+            .forEach(e->participationManagementService.failedPaymentParticipation
+                (e.getParticipationId(),e.getUserId()));
     }
 
 

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -18,6 +18,7 @@ import com.zerobase.travel.type.DepositStatus;
 import com.zerobase.travel.type.ParticipationStatus;
 import com.zerobase.travel.type.RatingStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.List;
 import java.util.Objects;
@@ -317,4 +318,11 @@ public class ParticipationService {
     }
 
 
+    public List<ParticipationDto> getParticipationsByJoinReadyFor24Hours() {
+        List<ParticipationEntity> participationEntities
+            = participationRepository.findAllByParticipationStatusAndCreatedAtBefore
+            (ParticipationStatus.JOIN_READY, LocalDateTime.now().minusDays(1L));
+
+        return participationEntities.stream().map(ParticipationDto::fromEntity).toList();
+    }
 }


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
JoinReady 후 결제신청 단계까지 넘어가지 못한 데이터 정리 스케줄러 도입

**AS-IS**
사용자가 참여신청 후, 결제단계까지 연계하는 과정을 프론트의 API 호출에 의존하는 구조로
이과정에서 사용자의 비정상 동작/ 통신오류로 비정상 데이터 잔여할 수 있음

**TO-BE**
매시간 정각 24시간이 경과한 잔여데이터 정리하는 스케줄러 도입
- 비정상 케이스가 많이 발생할 것으로 예상되지는 않아 별도 페이징 처리는 하지 않음.

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
JPA Audit 기능 작동하도록 Participation Entity 내 Listener 추가

## 📊 테스트
- [x] API 테스트 
