### PR TITLE
다른 사람 정보 조회 시, mbti 필드 추가

### DIFF
--- a/user/src/main/java/com/zerobase/user/dto/response/OtherUserInfoResponseDTO.java
+++ b/user/src/main/java/com/zerobase/user/dto/response/OtherUserInfoResponseDTO.java
@@ -22,6 +22,7 @@ public class OtherUserInfoResponseDTO {
     private String fileAddress;
     private String gender;
     private String status;
+    private String mbti;
 
     public static OtherUserInfoResponseDTO fromDto(UserInfoFacadeDto userInfoFacadeDto) {
         return OtherUserInfoResponseDTO.builder()
@@ -30,6 +31,7 @@ public class OtherUserInfoResponseDTO {
             .email(userInfoFacadeDto.getEmail())
             .count(userInfoFacadeDto.getCount())
             .fileAddress(userInfoFacadeDto.getFileAddress())
+            .mbti(userInfoFacadeDto.getMbti().name())
             .ratingAvg(userInfoFacadeDto.getRatingAvg())
             .gender(userInfoFacadeDto.getGender().getGender())
             .status(userInfoFacadeDto.getStatus().getUserStatus())

--- a/user/src/main/java/com/zerobase/user/type/MBTI.java
+++ b/user/src/main/java/com/zerobase/user/type/MBTI.java
@@ -1,5 +1,8 @@
 package com.zerobase.user.type;
 
+import lombok.Getter;
+
+@Getter
 public enum MBTI {
     INTJ, INTP, ENTJ, ENTP, INFJ, INFP, ENFJ, ENFP, ISTJ, ISFJ, ESTJ, ESFJ, ISTP, ISFP, ESTP, ESFP
 }


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제

다른 사람의 프로필을 조회할 때 MBTI 필드가 조회되지 않는 문제가 있었습니다. 사용자들은 다른 사용자의 MBTI 정보를 확인하고 싶어하지만, 현재 API에서는 해당 정보를 제공하지 않고 있습니다. 이를 해결하기 위해 다른 사용자 프로필 조회 시 MBTI 필드를 추가로 조회하도록 수정합니다.

## 🔑 PR에서 핵심적으로 변경된 사항

**AS-IS**

- `OtherUserInfoResponseDTO` 클래스에는 `mbti` 필드가 존재하지 않아, 다른 사용자 프로필 조회 시 MBTI 정보를 제공하지 못했습니다.
- `UserInfoFacadeDto`에서 가져온 MBTI 정보를 `OtherUserInfoResponseDTO`로 매핑하지 않았습니다.

**TO-BE**

- `OtherUserInfoResponseDTO` 클래스에 `mbti` 필드를 추가하였습니다.
  ```java
  private String mbti;
  ```
- `UserInfoFacadeDto`에서 가져온 MBTI 정보를 `OtherUserInfoResponseDTO`로 매핑하도록 수정하였습니다.
  ```java
  .mbti(userInfoFacadeDto.getMbti().name())
  ```
- 이를 통해 다른 사용자 프로필 조회 시 MBTI 정보가 포함되어 응답되며, 사용자들은 다른 사용자의 MBTI를 확인할 수 있게 되었습니다.

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분

- **`MBTI` Enum 클래스에 `@Getter` 어노테이션 추가**: 필요에 따라 `MBTI` Enum 클래스에 Lombok의 `@Getter` 어노테이션을 추가.
  ```java
  @Getter
  public enum MBTI {
      // 기존 내용 유지
  }
  ```