### PR TITLE
[HotFix] 모집게시글 상세조회시 일정순서가 랜덤으로 조회되던 문제

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/post/entity/DayDetailEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/DayDetailEntity.java
@@ -28,5 +28,9 @@ public class DayDetailEntity {
 
     @Column(name = "file_address")
     private String fileAddress;
+
+    //순서를 위한 필드 추가
+    @Column(name = "order_number")
+    private Integer orderNumber;
 }
 

--- a/travel/src/main/java/com/zerobase/travel/post/entity/DayEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/DayEntity.java
@@ -1,9 +1,26 @@
 package com.zerobase.travel.post.entity;
 
-import jakarta.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -25,20 +42,25 @@ public class DayEntity {
     private PostEntity post;
 
     // Day와 DayDetail 간의 연관관계 설정
+    @OrderColumn(name = "order_number")
     @OneToMany(mappedBy = "day", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private Set<DayDetailEntity> dayDetails = new HashSet<>();
+    private List<DayDetailEntity> dayDetails = new ArrayList<>();
 
     // Day와 ItineraryVisit 간의 연관관계 설정
+    @OrderColumn(name = "order_number")
     @OneToMany(mappedBy = "day", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private Set<ItineraryVisitEntity> itineraryVisits = new HashSet<>();
+    private List<ItineraryVisitEntity> itineraryVisits = new ArrayList<>();
 
     // 연관관계 편의 메서드 for DayDetailEntity
     public void addDayDetail(DayDetailEntity dayDetail) {
-        dayDetails.add(dayDetail);
-        dayDetail.setDay(this);
+        if (!dayDetails.contains(dayDetail)) {
+            dayDetails.add(dayDetail);
+            dayDetail.setDay(this);
+        }
     }
+
 
     public void removeDayDetail(DayDetailEntity dayDetail) {
         dayDetails.remove(dayDetail);
@@ -47,12 +69,27 @@ public class DayEntity {
 
     // 연관관계 편의 메서드 for ItineraryVisitEntity
     public void addItineraryVisit(ItineraryVisitEntity itineraryVisit) {
-        itineraryVisits.add(itineraryVisit);
-        itineraryVisit.setDay(this);
+        if (!itineraryVisits.contains(itineraryVisit)) {
+            itineraryVisits.add(itineraryVisit);
+            itineraryVisit.setDay(this);
+        }
     }
 
     public void removeItineraryVisit(ItineraryVisitEntity itineraryVisit) {
         itineraryVisits.remove(itineraryVisit);
         itineraryVisit.setDay(null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DayEntity)) return false;
+        DayEntity that = (DayEntity) o;
+        return Objects.equals(dayId, that.dayId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dayId);
     }
 }

--- a/travel/src/main/java/com/zerobase/travel/post/entity/PostEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/PostEntity.java
@@ -20,8 +20,8 @@ import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -106,22 +106,22 @@ public class PostEntity {
     // Post와 Day 간의 연관관계 설정
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private Set<DayEntity> days = new HashSet<>();
-
-
+    private List<DayEntity> days = new ArrayList<>();
 
     public static boolean validateUserAge(PostEntity postEntity, int userAge) {
-        if (postEntity.getLimitMinAge() > userAge || postEntity.getLimitMaxAge() < userAge) return false;
+        if (postEntity.getLimitMinAge() > userAge || postEntity.getLimitMaxAge() < userAge) {
+            return false;
+        }
         return true;
     }
 
     public static boolean validateUserGender(PostEntity postEntity, Gender userGender) {
         if (postEntity.getLimitSex().equals(LimitSex.FEMALE)) {
-            if(userGender.equals(Gender.MALE)){
+            if (userGender.equals(Gender.MALE)) {
                 return false;
             }
         } else if (postEntity.getLimitSex().equals(LimitSex.MALE)) {
-            if(userGender.equals(Gender.FEMALE)){
+            if (userGender.equals(Gender.FEMALE)) {
                 return false;
             }
         }
@@ -133,7 +133,7 @@ public class PostEntity {
 
         if (postEntity.getLimitSmoke().equals(LimitSmoke.SMOKER)) {
             if (userSmoking.equals(Smoking.NO)) {
-                    return false;
+                return false;
             }
         } else if (postEntity.getLimitSmoke().equals(LimitSmoke.NON_SMOKER)) {
             if (userSmoking.equals(Smoking.YES)) {

--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -26,6 +26,7 @@ import com.zerobase.travel.post.type.MBTI;
 import com.zerobase.travel.post.type.PostStatus;
 import feign.FeignException;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -279,23 +280,26 @@ public class PostService {
             .limitSmoke(existingPost.getLimitSmoke().getSmoke())
             .deadline(existingPost.getDeadline())
             .days(existingPost.getDays().stream()
+                .sorted(Comparator.comparingInt(existingPost.getDays()::indexOf))
                 .map(dayEntity -> DayDTO.builder()
-                    .dayDetails(
-                        dayEntity.getDayDetails().stream()
-                            .map(dayDetailEntity -> DayDetailDTO.builder()
-                                .title(dayDetailEntity.getTitle())
-                                .description(dayDetailEntity.getDescription())
-                                .fileAddress(dayDetailEntity.getFileAddress())
-                                .build()).collect(Collectors.toList()))
+                    .dayDetails(dayEntity.getDayDetails().stream()
+                        .sorted(Comparator.comparingInt(dayEntity.getDayDetails()::indexOf))
+                        .map(dayDetailEntity -> DayDetailDTO.builder()
+                            .title(dayDetailEntity.getTitle())
+                            .description(dayDetailEntity.getDescription())
+                            .fileAddress(dayDetailEntity.getFileAddress())
+                            .build())
+                        .collect(Collectors.toList()))
                     .itineraryVisits(dayEntity.getItineraryVisits().stream()
+                        .sorted(Comparator.comparingInt(ItineraryVisitEntity::getOrderNumber))
                         .map(visitEntity -> ItineraryVisitDTO.builder()
-                            .latitude(
-                                visitEntity.getPoint().getY()) // Latitude는 Y 좌표
-                            .longitude(visitEntity.getPoint()
-                                .getX()) // Longitude는 X 좌표
+                            .latitude(visitEntity.getPoint().getY())
+                            .longitude(visitEntity.getPoint().getX())
                             .orderNumber(visitEntity.getOrderNumber())
-                            .build()).collect(Collectors.toList()))
-                    .build()).collect(Collectors.toList()))
+                            .build())
+                        .collect(Collectors.toList()))
+                    .build())
+                .collect(Collectors.toList()))
             .build();
     }
 


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제

게시물 상세 조회 및 게시물 목록 조회 시 데이터의 순서가 뒤바뀌어 조회되는 문제를 해결. 기존에는 데이터가 등록된 순서대로 조회되지 않고, 매번 순서가 변경되어 사용자에게 혼란을 주는 이슈가 있었습니다.

## 🔑 PR에서 핵심적으로 변경된 사항

**AS-IS**

- 엔티티 클래스(`PostEntity`, `DayEntity` 등)에서 연관된 컬렉션들을 `Set`으로 정의하고 있었습니다.
- `Set`은 요소의 순서를 보장하지 않기 때문에 조회 시 데이터의 순서가 뒤바뀌는 문제가 발생했습니다.
- 게시물 상세 조회 시 `days`, `dayDetails`, `itineraryVisits` 등의 순서가 랜덤하게 나타났습니다.

**TO-BE**

- 엔티티 클래스에서 연관된 컬렉션 타입을 `Set`에서 `List`로 변경하였습니다.
  ```java
  // 변경 전
  private Set<DayEntity> days = new HashSet<>();
  
  // 변경 후
  private List<DayEntity> days = new ArrayList<>();
  ```
- `List`는 요소의 삽입 순서를 유지하므로, 데이터가 등록된 순서대로 조회됩니다.
- 서비스 계층에서 엔티티를 DTO로 매핑할 때, 컬렉션을 정렬하여 순서를 보장하였습니다.
  ```java
  // 예시 코드
  existingPost.getDays().stream()
      .sorted(Comparator.comparingInt(existingPost.getDays()::indexOf))
      .map(dayEntity -> { /* 매핑 로직 */ })
      .collect(Collectors.toList());
  ```
- 이를 통해 게시물 상세 조회 및 목록 조회 시 데이터의 순서가 올바르게 표시됩니다.

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분

- **중복 데이터 방지 로직 추가**: `List`로 변경함에 따라 중복된 데이터가 저장될 수 있으므로, 중복 추가를 방지하기 위한 로직을 연관 관계 편의 메서드에 추가하였습니다.
  ```java
  public void addDay(DayEntity day) {
      if (!days.contains(day)) {
          days.add(day);
          day.setPost(this);
      }
  }
  ```
- **`equals`와 `hashCode` 메서드 재정의**: 엔티티 클래스에서 중복 체크를 위해 `equals`와 `hashCode` 메서드를 재정의하였습니다.
  ```java
  @Override
  public boolean equals(Object o) {
      if (this == o) return true;
      if (!(o instanceof DayEntity)) return false;
      DayEntity that = (DayEntity) o;
      return Objects.equals(dayId, that.dayId);
  }

  @Override
  public int hashCode() {
      return Objects.hash(dayId);
  }
  ```
- **정렬 기준 필드 추가**: 필요에 따라 `orderNumber`와 같은 정렬 기준 필드를 엔티티에 추가하여 데이터의 순서를 명확히 하였습니다.

- **서비스 로직 개선**: 서비스 계층에서 컬렉션을 처리할 때, 순서를 유지하고 중복을 방지하기 위한 로직을 추가하여 데이터의 일관성을 높였습니다.