### PR TITLE
모집 게시글 목록 조회시, 작성자 MBTI 필드 추가.

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/post/dto/response/ResponsePostDTO.java
+++ b/travel/src/main/java/com/zerobase/travel/post/dto/response/ResponsePostDTO.java
@@ -30,6 +30,9 @@ public class ResponsePostDTO {
     private String limitSex;
     private String limitSmoke;
     private String status;
+    private String mbti;
+    private String username;
+    private String profilePicture;
     private LocalDate deadline;
     private List<DayDTO> days;
 }

--- a/travel/src/main/java/com/zerobase/travel/post/dto/response/ResponsePostsDTO.java
+++ b/travel/src/main/java/com/zerobase/travel/post/dto/response/ResponsePostsDTO.java
@@ -31,6 +31,7 @@ public class ResponsePostsDTO {
     private String limitSex;
     private String limitSmoke;
     private String status;
+    private String mbti;
     private LocalDate deadline;
     private List<DayDTO> days;
 }

--- a/travel/src/main/java/com/zerobase/travel/post/dto/response/ResponsePostsDTO.java
+++ b/travel/src/main/java/com/zerobase/travel/post/dto/response/ResponsePostsDTO.java
@@ -32,6 +32,8 @@ public class ResponsePostsDTO {
     private String limitSmoke;
     private String status;
     private String mbti;
+    private String nickname;
+    private String profileFileAddress;
     private LocalDate deadline;
     private List<DayDTO> days;
 }

--- a/travel/src/main/java/com/zerobase/travel/post/dto/response/UserInfoResponseDTO.java
+++ b/travel/src/main/java/com/zerobase/travel/post/dto/response/UserInfoResponseDTO.java
@@ -26,5 +26,6 @@ public class UserInfoResponseDTO {
     private String introduction;
     private Gender gender;
     private LocalDate birth;
+    private String fileAddress;
     private Double ratingAvg;
 }

--- a/travel/src/main/java/com/zerobase/travel/post/entity/UserClient.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/UserClient.java
@@ -38,4 +38,7 @@ public interface UserClient {
     @GetMapping("/internal/api/v1/users/{userEmail}")
     ResponseEntity<ResponseMessage<UserInfoResponseDTO>> getUserInfoByUserEmail(
         @PathVariable String userEmail);
+
+    @GetMapping("/internal/api/v1/users/id/{userId}")
+    ResponseMessage<UserInfoResponseDTO> getUserInfoByUserId(@PathVariable long userId);
 }

--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -331,6 +331,7 @@ public class PostService {
             .limitMaxAge(existingPost.getLimitMaxAge())
             .limitSex(existingPost.getLimitSex().getSex())
             .limitSmoke(existingPost.getLimitSmoke().getSmoke())
+            .mbti(existingPost.getMbti().name())
             .status(existingPost.getStatus().getPostStatus())
             .deadline(existingPost.getDeadline())
             .days(existingPost.getDays().stream()

--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -260,9 +260,14 @@ public class PostService {
             throw new BizException(POST_NOT_FOUND_ERROR);
         }
 
+        UserInfoResponseDTO userInfo = userClientService.getUserInfoByUserId(existingPost.getUserId());
+
         // ResponsePostDTO 빌드
         return ResponsePostDTO.builder()
             .userId(existingPost.getUserId())
+            .mbti(userInfo.getMbti().name())
+            .username(userInfo.getUsername())
+            .profilePicture(userInfo.getFileAddress())
             .title(existingPost.getTitle())
             .travelStartDate(existingPost.getTravelStartDate())
             .travelEndDate(existingPost.getTravelEndDate())
@@ -310,6 +315,7 @@ public class PostService {
         // 'others=true'인 경우, country는 이미 criteria에 반영됨
         return postRepository.findAll(PostSpecification.getPosts(criteria),
                 pageable)
+
             .map(this::mapToDTO);
     }
 
@@ -317,6 +323,8 @@ public class PostService {
         return ResponsePostsDTO.builder()
             .postId(existingPost.getPostId())
             .userId(existingPost.getUserId())
+            .nickname(userClientService.getUserInfoByUserId(existingPost.getUserId()).getNickname())
+            .profileFileAddress(userClientService.getUserInfoByUserId(existingPost.getUserId()).getFileAddress())
             .title(existingPost.getTitle())
             .travelStartDate(existingPost.getTravelStartDate())
             .travelEndDate(existingPost.getTravelEndDate())

--- a/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/PostService.java
@@ -27,7 +27,6 @@ import com.zerobase.travel.post.type.PostStatus;
 import feign.FeignException;
 import java.time.LocalDate;
 import java.util.Comparator;
-import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -260,7 +259,8 @@ public class PostService {
             throw new BizException(POST_NOT_FOUND_ERROR);
         }
 
-        UserInfoResponseDTO userInfo = userClientService.getUserInfoByUserId(existingPost.getUserId());
+        UserInfoResponseDTO userInfo = userClientService.getUserInfoByUserId(
+            existingPost.getUserId());
 
         // ResponsePostDTO 빌드
         return ResponsePostDTO.builder()
@@ -320,11 +320,14 @@ public class PostService {
     }
 
     private ResponsePostsDTO mapToDTO(PostEntity existingPost) {
+        UserInfoResponseDTO userInfoByUserId = userClientService.getUserInfoByUserId(
+            existingPost.getUserId());
+
         return ResponsePostsDTO.builder()
             .postId(existingPost.getPostId())
             .userId(existingPost.getUserId())
-            .nickname(userClientService.getUserInfoByUserId(existingPost.getUserId()).getNickname())
-            .profileFileAddress(userClientService.getUserInfoByUserId(existingPost.getUserId()).getFileAddress())
+            .nickname(userInfoByUserId.getNickname())
+            .profileFileAddress(userInfoByUserId.getFileAddress())
             .title(existingPost.getTitle())
             .travelStartDate(existingPost.getTravelStartDate())
             .travelEndDate(existingPost.getTravelEndDate())
@@ -391,7 +394,9 @@ public class PostService {
             updatedCount += affectedRows;
 
             // 더 이상 업데이트할 행이 없으면 종료
-            if (affectedRows == 0) break;
+            if (affectedRows == 0) {
+                break;
+            }
 
             log.info("벌크 업데이트 진행 중... 현재까지 업데이트된 게시물 수: {}", updatedCount);
         }

--- a/travel/src/main/java/com/zerobase/travel/post/service/UserClientService.java
+++ b/travel/src/main/java/com/zerobase/travel/post/service/UserClientService.java
@@ -35,4 +35,14 @@ public class UserClientService {
             throw new BizException(USER_INFO_CALL_ERROR);
         }
     }
+
+    public UserInfoResponseDTO getUserInfoByUserId(long userId) {
+        ResponseMessage<UserInfoResponseDTO> response = userClient.getUserInfoByUserId(userId);
+        if (response.getResult().equals(SUCCESS.toString())) {
+            return response.getData();
+        } else {
+            // 에러 처리 로직 추가
+            throw new BizException(USER_INFO_CALL_ERROR);
+        }
+    }
 }

--- a/travel/src/main/java/com/zerobase/travel/post/type/MBTI.java
+++ b/travel/src/main/java/com/zerobase/travel/post/type/MBTI.java
@@ -1,5 +1,8 @@
 package com.zerobase.travel.post.type;
 
+import lombok.Getter;
+
+@Getter
 public enum MBTI {
     INTJ, INTP, ENTJ, ENTP, INFJ, INFP, ENFJ, ENFP, ISTJ, ISFJ, ESTJ, ESFJ, ISTP, ISFP, ESTP, ESFP
 }

--- a/user/src/main/java/com/zerobase/user/controller/InternalUserController.java
+++ b/user/src/main/java/com/zerobase/user/controller/InternalUserController.java
@@ -54,13 +54,23 @@ public class InternalUserController {
         ));
     }
 
-    // 프로필 조회
+    // 사용자 이메일로 프로필 조회
     @GetMapping("/{userEmail}")
     public ResponseEntity<ResponseMessage<InternalUserInfoResponseDTO>> getUserEmail(
         @PathVariable String userEmail) {
         UserServiceDto byUserWithEmail = userService.findByUserWithEmail(userEmail);
         return ResponseEntity.status(OK).body(ResponseMessage.success(
             InternalUserInfoResponseDTO.fromDto(byUserWithEmail))
+        );
+    }
+
+    // 사용자 아이디로 프로필 조회
+    @GetMapping("/id/{userId}")
+    public ResponseEntity<ResponseMessage<InternalUserInfoResponseDTO>> getUserInfoByUserId(
+        @PathVariable long userId) {
+        UserServiceDto byUserWithId = userService.findByUserWithId(userId);
+        return ResponseEntity.status(OK).body(ResponseMessage.success(
+            InternalUserInfoResponseDTO.fromDto(byUserWithId))
         );
     }
 

--- a/user/src/main/java/com/zerobase/user/dto/response/InternalUserInfoResponseDTO.java
+++ b/user/src/main/java/com/zerobase/user/dto/response/InternalUserInfoResponseDTO.java
@@ -30,6 +30,7 @@ public class InternalUserInfoResponseDTO {
     private String email;
     private UserStatus status;
     private MBTI mbti;
+    private String fileAddress;
     private Smoking smoking;
     private String introduction;
     private Gender gender;
@@ -52,6 +53,7 @@ public class InternalUserInfoResponseDTO {
             .introduction(byUserWithEmail.getIntroduction())
             .gender(byUserWithEmail.getGender())
             .birth(byUserWithEmail.getBirth())
+            .fileAddress(byUserWithEmail.getFileAddress())
             .ratingAvg(byUserWithEmail.getRatingAvg())
             .build();
     }

--- a/user/src/main/java/com/zerobase/user/service/UserService.java
+++ b/user/src/main/java/com/zerobase/user/service/UserService.java
@@ -254,6 +254,7 @@ public class UserService {
             .smoking(profileEntity.getSmoking())
             .gender(profileEntity.getGender())
             .mbti(profileEntity.getMbti())
+            .fileAddress(profileEntity.getFileAddress())
             .birth(profileEntity.getBirth())
             .ratingAvg(profileEntity.getRatingAvg())
             .build();
@@ -280,5 +281,31 @@ public class UserService {
         redisTemplate.delete(profileKey);
 
         log.info("Cache deleted for user ID: {}", userId);
+    }
+
+    public UserServiceDto findByUserWithId(long userId) {
+        UserEntity userEntity = userRepository.findById(userId)
+            .orElseThrow(() -> new BizException(USER_NOT_FOUND_ERROR));
+
+        ProfileEntity profileEntity = profileRepository.findByUserId(userEntity.getId())
+            .orElseThrow(() -> new BizException(PROFILE_NOT_FOUND_ERROR));
+
+        UserServiceDto userInfo = UserServiceDto.builder()
+            .id(userEntity.getId())
+            .username(userEntity.getUsername())
+            .nickname(userEntity.getNickname())
+            .email(userEntity.getEmail())
+            .status(userEntity.getStatus())
+            .phone(userEntity.getPhone())
+            .introduction(profileEntity.getIntroduction())
+            .smoking(profileEntity.getSmoking())
+            .gender(profileEntity.getGender())
+            .mbti(profileEntity.getMbti())
+            .fileAddress(profileEntity.getFileAddress())
+            .birth(profileEntity.getBirth())
+            .ratingAvg(profileEntity.getRatingAvg())
+            .build();
+
+        return userInfo;
     }
 }


### PR DESCRIPTION
### 🔍 PR을 통해 해결하려는 문제  
기존 게시글 조회 및 목록 API 응답 DTO(`ResponsePostDTO`, `ResponsePostsDTO`)에서 사용자 닉네임 및 프로필 사진과 같은 추가 사용자 정보가 표시되지 않아, UI 단에서 게시글 작성자에 대한 충분한 정보를 제공하기 어려웠습니다. 이 PR에서는 사용자 서비스를 통해 사용자 정보를 가져와 게시글 응답 DTO에 반영함으로써, 최종 클라이언트(프런트엔드)에서 추가적인 정보를 표시할 수 있도록 수정됨.

### 🔑 PR에서 핵심적으로 변경된 사항  
- `ResponsePostDTO`, `ResponsePostsDTO` DTO에 `nickname`, `profileFileAddress`, `mbti` 필드 추가  
- 기존 `UserClientService`에 `getUserInfoByUserId()` 메서드 추가  
- `PostService`의 `mapToDTO()` 로직에서 `UserClientService`를 호출해, 게시글 작성자의 닉네임, 프로필 파일 주소, MBTI를 DTO에 매핑  
- 상세 조회(`findPost`) 및 목록 조회(`searchPosts`) 시점에서 사용자 정보를 DTO에 포함하도록 변경

### AS-IS (변경 전)  
- 게시글 상세/목록 응답 DTO에 위에 3가지 사용자 정보 없음  
- `mapToDTO()` 내에서 게시글 정보만 DTO로 변환하며, 사용자 정보는 userId만 표시  
- 프런트엔드에서 별도의 호출을 통해 사용자 정보를 가져와야 하는 불편함 존재

### TO-BE (변경 후)  
- 게시글 상세/목록 응답 DTO에 사용자 정보(`nickname`, `profileFileAddress`, `mbti`) 포함  
- `mapToDTO()`에서 `userClientService.getUserInfoByUserId()` 호출로 사용자 정보 즉시 반영  
- 별도 API 호출 없이 하나의 응답에 게시글 및 작성자 정보가 함께 전달되어 클라이언트에서 편리하게 데이터 활용 가능

