### PR TITLE
feat : review 목록 response 데이터 추가

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/application/ReviewFacade.java
+++ b/travel/src/main/java/com/zerobase/travel/application/ReviewFacade.java
@@ -1,0 +1,29 @@
+package com.zerobase.travel.application;
+
+import com.zerobase.travel.application.dto.ReviewFacadeDto;
+import com.zerobase.travel.application.dto.ReviewFacadeDto.Review;
+import com.zerobase.travel.post.entity.UserClient;
+import com.zerobase.travel.repository.specification.ReviewSearchDto;
+import com.zerobase.travel.service.ReviewService;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ReviewFacade {
+
+    private final ReviewService reviewService;
+    private final UserClient userClient;
+
+    public Page<Review> getReviews(ReviewSearchDto reviewSearchDto, PageRequest pageRequest) {
+        return reviewService.getReviews(reviewSearchDto, pageRequest)
+            .map(review -> ReviewFacadeDto.Review.fromDto(
+                review,
+                userClient.searchUserInfo("userId", review.getUserId().toString()).getData()
+            ));
+
+    }
+
+}

--- a/travel/src/main/java/com/zerobase/travel/application/dto/ReviewFacadeDto.java
+++ b/travel/src/main/java/com/zerobase/travel/application/dto/ReviewFacadeDto.java
@@ -1,0 +1,111 @@
+package com.zerobase.travel.application.dto;
+
+import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
+import com.zerobase.travel.post.type.Gender;
+import com.zerobase.travel.post.type.MBTI;
+import com.zerobase.travel.post.type.Smoking;
+import com.zerobase.travel.post.type.UserStatus;
+import com.zerobase.travel.service.dto.ReviewServiceDto;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+public class ReviewFacadeDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class Review {
+        private Long reviewId;
+        private Long postId;
+        private Long userId;
+        private Continent continent;
+        private Country country;
+        private String region;
+        private String title;
+        private String contents;
+        private List<ReviewFacadeDto.ReviewFile> reviewFiles;
+
+        private User user;
+
+        public static Review fromDto(ReviewServiceDto.Review review, UserInfoResponseDTO dto) {
+            return Review.builder()
+                .reviewId(review.getReviewId())
+                .postId(review.getPostId())
+                .userId(review.getUserId())
+                .continent(review.getContinent())
+                .country(review.getCountry())
+                .region(review.getRegion())
+                .title(review.getTitle())
+                .contents(review.getContents())
+                .reviewFiles(
+                    review.getReviewFiles().stream()
+                        .map(ReviewFile::fromDto)
+                        .toList()
+                )
+                .user(User.fromDto(dto))
+                .build();
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class ReviewFile {
+
+        private Long id;
+        private String fileAddress;
+
+        public static ReviewFacadeDto.ReviewFile fromDto(ReviewServiceDto.ReviewFile reviewFile) {
+            return ReviewFacadeDto.ReviewFile.builder()
+                .id(reviewFile.getId())
+                .fileAddress(reviewFile.getFileAddress())
+                .build();
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class User {
+        private Long id;
+        private String username;
+        private String nickname;
+        private String phone;
+        private String email;
+        private UserStatus status;
+        private MBTI mbti;
+        private Smoking smoking;
+        private String introduction;
+        private Gender gender;
+        private LocalDate birth;
+        private String fileAddress;
+        private Double ratingAvg;
+
+        public static User fromDto(UserInfoResponseDTO dto) {
+            return User.builder()
+                .id(dto.getId())
+                .username(dto.getUsername())
+                .nickname(dto.getNickname())
+                .phone(dto.getPhone())
+                .email(dto.getEmail())
+                .status(dto.getStatus())
+                .mbti(dto.getMbti())
+                .smoking(dto.getSmoking())
+                .introduction(dto.getIntroduction())
+                .gender(dto.getGender())
+                .birth(dto.getBirth())
+                .fileAddress(dto.getFileAddress())
+                .ratingAvg(dto.getRatingAvg())
+                .build();
+        }
+    }
+}

--- a/travel/src/main/java/com/zerobase/travel/controller/ReviewController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ReviewController.java
@@ -1,11 +1,15 @@
 package com.zerobase.travel.controller;
 
+import com.zerobase.travel.application.ReviewFacade;
+import com.zerobase.travel.application.dto.ReviewFacadeDto.Review;
 import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.dto.request.ReviewRequestDto;
 import com.zerobase.travel.dto.response.ReviewResponseDto;
+import com.zerobase.travel.dto.response.ReviewResponseDto.ReviewPage;
 import com.zerobase.travel.repository.specification.ReviewSearchDto;
 import com.zerobase.travel.service.ReviewService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
     private final ReviewService reviewService;
-
+    private final ReviewFacade reviewFacade;
     @PostMapping("/posts/{postId}/reviews")
     public ResponseEntity<ResponseMessage<Void>> createReview(
         @RequestHeader("X-User-Email") String userEmail,
@@ -97,7 +101,7 @@ public class ReviewController {
             .build();
 
         return ResponseEntity.ok(ResponseMessage.success(
-            reviewService.getReviews(reviewSearchDto, pageRequest)
+            ReviewPage.fromDto(reviewFacade.getReviews(reviewSearchDto, pageRequest))
         ));
     }
 

--- a/travel/src/main/java/com/zerobase/travel/dto/response/ReviewResponseDto.java
+++ b/travel/src/main/java/com/zerobase/travel/dto/response/ReviewResponseDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.travel.dto.response;
 
+import com.zerobase.travel.application.dto.ReviewFacadeDto;
 import com.zerobase.travel.entity.ReviewEntity;
 import com.zerobase.travel.entity.ReviewFileEntity;
 import java.util.List;
@@ -10,6 +11,49 @@ import lombok.ToString;
 import org.springframework.data.domain.Page;
 
 public class ReviewResponseDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class ReviewList {
+
+        private Long reviewId;
+        private Long postId;
+        private Long userId;
+        private String continent;
+        private String country;
+        private String region;
+        private String title;
+        private String contents;
+        private String nickname;
+        private String mbti;
+        private String profileFileAddress;
+
+        private List<ReviewFile> files;
+
+        public static ReviewList fromDto(ReviewFacadeDto.Review entity) {
+            return ReviewList.builder()
+                .reviewId(entity.getReviewId())
+                .postId(entity.getPostId())
+                .userId(entity.getUserId())
+                .continent(entity.getContinent().toString())
+                .country(entity.getCountry().toString())
+                .region(entity.getRegion())
+                .title(entity.getTitle())
+                .contents(entity.getContents())
+                .nickname(entity.getUser().getNickname())
+                .mbti(entity.getUser().getMbti().toString())
+                .profileFileAddress(entity.getUser().getFileAddress())
+                .files(
+                    entity.getReviewFiles().stream()
+                        .map(ReviewFile::fromDto)
+                        .toList()
+                )
+                .build();
+        }
+
+    }
 
     @Getter
     @Setter
@@ -61,6 +105,12 @@ public class ReviewResponseDto {
                 .fileAddress(entity.getFileAddress())
                 .build();
         }
+
+        public static ReviewFile fromDto(ReviewFacadeDto.ReviewFile reviewFile) {
+            return ReviewFile.builder()
+                .fileAddress(reviewFile.getFileAddress())
+                .build();
+        }
     }
 
     @Getter
@@ -69,7 +119,7 @@ public class ReviewResponseDto {
     @ToString
     public static class ReviewPage {
 
-        private List<Review> reviews;
+        private List<ReviewList> reviews;
         private int pageNumber;
         private int pageSize;
         private long totalElements;
@@ -77,10 +127,10 @@ public class ReviewResponseDto {
         private boolean last;
 
 
-        public static ReviewPage fromPageEntity(Page<ReviewEntity> entityPage) {
+        public static ReviewPage fromDto(Page<ReviewFacadeDto.Review> entityPage) {
             return ReviewPage.builder()
                 .reviews(
-                    entityPage.map(ReviewResponseDto.Review::fromEntity).toList()
+                    entityPage.map(ReviewResponseDto.ReviewList::fromDto).toList()
                 )
                 .pageNumber(entityPage.getNumber())
                 .pageSize(entityPage.getSize())

--- a/travel/src/main/java/com/zerobase/travel/service/ReviewService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ReviewService.java
@@ -15,6 +15,7 @@ import com.zerobase.travel.post.entity.UserClient;
 import com.zerobase.travel.repository.ReviewFileRepository;
 import com.zerobase.travel.repository.ReviewRepository;
 import com.zerobase.travel.repository.specification.ReviewSpecification;
+import com.zerobase.travel.service.dto.ReviewServiceDto;
 import com.zerobase.travel.typeCommon.Continent;
 import com.zerobase.travel.typeCommon.Country;
 import lombok.RequiredArgsConstructor;
@@ -93,10 +94,10 @@ public class ReviewService {
 
     }
 
-    public ReviewPage getReviews(ReviewSearchDto reviewSearchDto, PageRequest pageRequest) {
+    public Page<ReviewServiceDto.Review> getReviews(ReviewSearchDto reviewSearchDto, PageRequest pageRequest) {
 
-        return ReviewPage.fromPageEntity(
-            reviewRepository.findAll(ReviewSpecification.filter(reviewSearchDto), pageRequest)
+        return reviewRepository.findAll(ReviewSpecification.filter(reviewSearchDto), pageRequest).map(
+            ReviewServiceDto.Review::fromEntity
         );
     }
 

--- a/travel/src/main/java/com/zerobase/travel/service/dto/ReviewServiceDto.java
+++ b/travel/src/main/java/com/zerobase/travel/service/dto/ReviewServiceDto.java
@@ -1,0 +1,69 @@
+package com.zerobase.travel.service.dto;
+
+
+import com.zerobase.travel.entity.ReviewEntity;
+import com.zerobase.travel.entity.ReviewFileEntity;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.domain.Page;
+
+public class ReviewServiceDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class Review {
+
+        private Long reviewId;
+        private Long postId;
+        private Long userId;
+        private Continent continent;
+        private Country country;
+        private String region;
+        private String title;
+        private String contents;
+        private List<ReviewFile> reviewFiles;
+
+        public static Review fromEntity(ReviewEntity reviewEntity) {
+            return Review.builder()
+                .reviewId(reviewEntity.getId())
+                .postId(reviewEntity.getPostId())
+                .userId(reviewEntity.getUserId())
+                .continent(reviewEntity.getContinent())
+                .country(reviewEntity.getCountry())
+                .region(reviewEntity.getRegion())
+                .title(reviewEntity.getTitle())
+                .contents(reviewEntity.getContents())
+                .reviewFiles(
+                    reviewEntity.getReviewFileList().stream()
+                        .map(ReviewFile::fromEntity)
+                        .toList()
+                )
+                .build();
+        }
+
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    public static class ReviewFile {
+
+        private Long id;
+        private String fileAddress;
+
+        public static ReviewFile fromEntity(ReviewFileEntity reviewFileEntity) {
+            return ReviewFile.builder()
+                .id(reviewFileEntity.getId())
+                .fileAddress(reviewFileEntity.getFileAddress())
+                .build();
+        }
+    }
+}

--- a/travel/src/test/java/com/zerobase/travel/application/ReviewFacadeTest.java
+++ b/travel/src/test/java/com/zerobase/travel/application/ReviewFacadeTest.java
@@ -1,0 +1,195 @@
+package com.zerobase.travel.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.zerobase.travel.application.dto.ReviewFacadeDto;
+import com.zerobase.travel.application.dto.ReviewFacadeDto.Review;
+import com.zerobase.travel.common.response.ResponseMessage;
+import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
+import com.zerobase.travel.post.entity.UserClient;
+import com.zerobase.travel.post.service.UserClientService;
+import com.zerobase.travel.post.type.Gender;
+import com.zerobase.travel.post.type.MBTI;
+import com.zerobase.travel.post.type.Smoking;
+import com.zerobase.travel.post.type.UserStatus;
+import com.zerobase.travel.repository.ReviewRepository;
+import com.zerobase.travel.repository.specification.ReviewSearchDto;
+import com.zerobase.travel.service.ReviewService;
+import com.zerobase.travel.service.dto.ReviewServiceDto;
+import com.zerobase.travel.typeCommon.Continent;
+import com.zerobase.travel.typeCommon.Country;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewFacadeTest {
+
+    @Mock
+    private ReviewService reviewService;
+
+    @Mock
+    private UserClient userClient;
+
+    @InjectMocks
+    private ReviewFacade reviewFacade;
+
+
+    @Test
+    void successGetReviews() {
+
+        //given
+        List<ReviewServiceDto.Review> reviewList = List.of(
+            ReviewServiceDto.Review.builder()
+                .reviewId(1L)
+                .postId(2L)
+                .userId(3L)
+                .continent(Continent.ASIA)
+                .country(Country.KR)
+                .region("서울")
+                .title("서울 여행")
+                .contents("서울여행 좋아요.")
+                .reviewFiles(List.of(
+                    ReviewServiceDto.ReviewFile.builder()
+                        .id(1L)
+                        .fileAddress("/asd/asd/asd")
+                        .build()
+                ))
+                .build(),
+            ReviewServiceDto.Review.builder()
+                .reviewId(2L)
+                .postId(3L)
+                .userId(4L)
+                .continent(Continent.EUROPE)
+                .country(Country.FR)
+                .region("프랑스")
+                .title("프랑스 여행")
+                .contents("프랑스여행 좋아요.")
+                .reviewFiles(List.of(
+                    ReviewServiceDto.ReviewFile.builder()
+                        .id(2L)
+                        .fileAddress("/zxc/zxc/zxc")
+                        .build()
+                ))
+                .build()
+        );
+
+        List<ResponseMessage<UserInfoResponseDTO>> userInfoResponseList = List.of(
+            ResponseMessage.success(
+                UserInfoResponseDTO.builder()
+                    .id(3L)
+                    .username("user123")
+                    .nickname("닉네임123")
+                    .phone("010-1234-5678")
+                    .email("user123@example.com")
+                    .status(UserStatus.ACTIVE)
+                    .mbti(MBTI.ENFJ)
+                    .smoking(Smoking.YES)
+                    .introduction("안녕하세요! 반갑습니다.")
+                    .gender(Gender.FEMALE)
+                    .birth(LocalDate.of(1990, 1, 1))
+                    .fileAddress("/qwe/qwe/qwe")
+                    .ratingAvg(4.5)
+                    .build())
+            ,
+            ResponseMessage.success(
+                UserInfoResponseDTO.builder()
+                    .id(4L)
+                    .username("user456")
+                    .nickname("닉네임456")
+                    .phone("010-5678-1234")
+                    .email("user456@example.com")
+                    .status(UserStatus.INACTIVE)
+                    .mbti(MBTI.INTJ)
+                    .smoking(Smoking.NO)
+                    .introduction("다들 안녕하세요!")
+                    .gender(Gender.MALE)
+                    .birth(LocalDate.of(1985, 5, 20))
+                    .fileAddress("/asd/asd/asd")
+                    .ratingAvg(3.8)
+                    .build()
+            )
+        );
+
+        Page<ReviewServiceDto.Review> reviewPage = new PageImpl<>(reviewList, PageRequest.of(0, 8), reviewList.size());
+
+        given(reviewService.getReviews(any(), any()))
+            .willReturn(reviewPage);
+
+        given(userClient.searchUserInfo(any(), any()))
+            .willReturn(userInfoResponseList.get(0), userInfoResponseList.get(1));
+
+        //when
+        Page<ReviewFacadeDto.Review> reviews = reviewFacade.getReviews(ReviewSearchDto.builder().build(), PageRequest.of(0, 8));
+
+        //then
+        assertNotNull(reviews);
+        assertEquals(0, reviews.getNumber());
+        assertEquals(8, reviews.getSize());
+        assertEquals(2, reviews.getTotalElements());
+        assertEquals(1, reviews.getTotalPages());
+        assertTrue(reviews.isLast());
+
+        // Review 1 검증
+        ReviewFacadeDto.Review review1 = reviews.getContent().get(0);
+        assertEquals(1L, review1.getReviewId());
+        assertEquals(2L, review1.getPostId());
+        assertEquals(3L, review1.getUserId());
+        assertEquals(Continent.ASIA, review1.getContinent());
+        assertEquals(Country.KR, review1.getCountry());
+        assertEquals("서울", review1.getRegion());
+        assertEquals("서울 여행", review1.getTitle());
+        assertEquals("서울여행 좋아요.", review1.getContents());
+        assertEquals(1L, review1.getReviewFiles().get(0).getId());
+        assertEquals("/asd/asd/asd", review1.getReviewFiles().get(0).getFileAddress());
+        assertEquals(3L, review1.getUser().getId());
+        assertEquals("user123", review1.getUser().getUsername());
+        assertEquals("닉네임123", review1.getUser().getNickname());
+        assertEquals("010-1234-5678", review1.getUser().getPhone());
+        assertEquals("user123@example.com", review1.getUser().getEmail());
+        assertEquals(UserStatus.ACTIVE, review1.getUser().getStatus());
+        assertEquals(MBTI.ENFJ, review1.getUser().getMbti());
+        assertEquals(Smoking.YES, review1.getUser().getSmoking());
+        assertEquals("안녕하세요! 반갑습니다.", review1.getUser().getIntroduction());
+        assertEquals(Gender.FEMALE, review1.getUser().getGender());
+        assertEquals(LocalDate.of(1990, 1, 1), review1.getUser().getBirth());
+        assertEquals("/qwe/qwe/qwe", review1.getUser().getFileAddress());
+        assertEquals(4.5, review1.getUser().getRatingAvg());
+
+
+        // Review 2 검증
+        ReviewFacadeDto.Review review2 = reviews.getContent().get(1);
+        assertEquals(2L, review2.getReviewId());
+        assertEquals(3L, review2.getPostId());
+        assertEquals(4L, review2.getUserId());
+        assertEquals(Continent.EUROPE, review2.getContinent());
+        assertEquals(Country.FR, review2.getCountry());
+        assertEquals("프랑스", review2.getRegion());
+        assertEquals("프랑스 여행", review2.getTitle());
+        assertEquals("프랑스여행 좋아요.", review2.getContents());
+        assertEquals(2L, review2.getReviewFiles().get(0).getId());
+        assertEquals("/zxc/zxc/zxc", review2.getReviewFiles().get(0).getFileAddress());
+        assertEquals(4L, review2.getUser().getId());
+        assertEquals("user456", review2.getUser().getUsername());
+        assertEquals("닉네임456", review2.getUser().getNickname());
+        assertEquals("010-5678-1234", review2.getUser().getPhone());
+        assertEquals("user456@example.com", review2.getUser().getEmail());
+        assertEquals(UserStatus.INACTIVE, review2.getUser().getStatus());
+        assertEquals(MBTI.INTJ, review2.getUser().getMbti());
+        assertEquals(Smoking.NO, review2.getUser().getSmoking());
+        assertEquals("다들 안녕하세요!", review2.getUser().getIntroduction());
+        assertEquals(Gender.MALE, review2.getUser().getGender());
+        assertEquals(LocalDate.of(1985, 5, 20), review2.getUser().getBirth());
+        assertEquals("/asd/asd/asd", review2.getUser().getFileAddress());
+        assertEquals(3.8, review2.getUser().getRatingAvg());
+    }
+}

--- a/travel/src/test/java/com/zerobase/travel/service/ReviewServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/service/ReviewServiceTest.java
@@ -12,19 +12,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.zerobase.travel.dto.request.ReviewRequestDto;
-import com.zerobase.travel.dto.response.ReviewResponseDto;
 import com.zerobase.travel.dto.response.ReviewResponseDto.Review;
-import com.zerobase.travel.dto.response.ReviewResponseDto.ReviewPage;
 import com.zerobase.travel.entity.ReviewEntity;
 import com.zerobase.travel.entity.ReviewFileEntity;
 import com.zerobase.travel.exception.BizException;
 import com.zerobase.travel.exception.errorcode.ReviewErrorCode;
 import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
-import com.zerobase.travel.post.entity.UserClient;
 import com.zerobase.travel.post.service.UserClientService;
-import com.zerobase.travel.repository.ReviewFileRepository;
 import com.zerobase.travel.repository.ReviewRepository;
 import com.zerobase.travel.repository.specification.ReviewSearchDto;
+import com.zerobase.travel.service.dto.ReviewServiceDto;
 import com.zerobase.travel.typeCommon.Continent;
 import com.zerobase.travel.typeCommon.Country;
 import java.util.List;
@@ -46,9 +43,6 @@ class ReviewServiceTest {
 
     @Mock
     private ReviewRepository reviewRepository;
-
-    @Mock
-    private ReviewFileRepository reviewFileRepository;
 
     @Mock
     private UserClientService userClientService;
@@ -483,52 +477,52 @@ class ReviewServiceTest {
             .willReturn(entityPage);
 
         // when
-        ReviewPage reviewPage = reviewService.getReviews(ReviewSearchDto.builder().build(), pageRequest);
+        Page<ReviewServiceDto.Review> reviewPage = reviewService.getReviews(ReviewSearchDto.builder().build(), pageRequest);
 
         // then
         assertNotNull(reviewPage);
-        assertEquals(0, reviewPage.getPageNumber());
-        assertEquals(3, reviewPage.getPageSize());
+        assertEquals(0, reviewPage.getNumber());
+        assertEquals(3, reviewPage.getSize());
         assertEquals(10, reviewPage.getTotalElements());
         assertEquals(4, reviewPage.getTotalPages());
         assertFalse(reviewPage.isLast());
 
         // Review 1 검증
-        ReviewResponseDto.Review review1 = reviewPage.getReviews().get(0);
+        ReviewServiceDto.Review review1 = reviewPage.getContent().get(0);
         assertEquals(1L, review1.getReviewId());
         assertEquals(1L, review1.getPostId());
         assertEquals(3L, review1.getUserId());
-        assertEquals(Continent.ASIA.toString(), review1.getContinent());
-        assertEquals(Country.KR.toString(), review1.getCountry());
+        assertEquals(Continent.ASIA, review1.getContinent());
+        assertEquals(Country.KR, review1.getCountry());
         assertEquals("서울", review1.getRegion());
         assertEquals("서울 여행", review1.getTitle());
         assertEquals("서울 여행 좋아요", review1.getContents());
-        assertEquals("/asd/asd/asd", review1.getFiles().get(0).getFileAddress());
-        assertEquals("/zxc/zxc/zxc", review1.getFiles().get(1).getFileAddress());
+        assertEquals("/asd/asd/asd", review1.getReviewFiles().get(0).getFileAddress());
+        assertEquals("/zxc/zxc/zxc", review1.getReviewFiles().get(1).getFileAddress());
 
         // Review 2 검증
-        ReviewResponseDto.Review review2 = reviewPage.getReviews().get(1);
+        ReviewServiceDto.Review review2 = reviewPage.getContent().get(1);
         assertEquals(2L, review2.getReviewId());
         assertEquals(1L, review2.getPostId());
         assertEquals(4L, review2.getUserId());
-        assertEquals(Continent.EUROPE.toString(), review2.getContinent());
-        assertEquals(Country.FR.toString(), review2.getCountry());
+        assertEquals(Continent.EUROPE, review2.getContinent());
+        assertEquals(Country.FR, review2.getCountry());
         assertEquals("파리", review2.getRegion());
         assertEquals("파리 여행", review2.getTitle());
         assertEquals("파리 여행 추천해요", review2.getContents());
-        assertEquals("/qwe/qwe/qwe", review2.getFiles().get(0).getFileAddress());
+        assertEquals("/qwe/qwe/qwe", review2.getReviewFiles().get(0).getFileAddress());
 
         // Review 3 검증
-        ReviewResponseDto.Review review3 = reviewPage.getReviews().get(2);
+        ReviewServiceDto.Review review3 = reviewPage.getContent().get(2);
         assertEquals(3L, review3.getReviewId());
         assertEquals(1L, review3.getPostId());
         assertEquals(5L, review3.getUserId());
-        assertEquals(Continent.ASIA.toString(), review3.getContinent());
-        assertEquals(Country.JP.toString(), review3.getCountry());
+        assertEquals(Continent.ASIA, review3.getContinent());
+        assertEquals(Country.JP, review3.getCountry());
         assertEquals("도쿄", review3.getRegion());
         assertEquals("도쿄 여행", review3.getTitle());
         assertEquals("도쿄 여행이 최고에요", review3.getContents());
-        assertEquals("/xyz/xyz/xyz", review3.getFiles().get(0).getFileAddress());
+        assertEquals("/xyz/xyz/xyz", review3.getReviewFiles().get(0).getFileAddress());
     }
 
 }


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
1. review 목록 response 데이터 추가
2. review 코드 구조 개선

## 🔑 PR에서 핵심적으로 변경된 사항
1. review 목록 response 데이터에 review 작성자 mbti, nickname. 프로필사진경로 추가
2. Facade 도입
    reviewService에 변경사항을 최소화하고 재사용성을 높이기 위하여 도입
4. 각레이어에 맞는 DTO 도입
    기존 Controller에서 사용하던 Dto가 service에서도 사용되어 response가 변경됨에 따라 Service가 영향을 받았음.
    위의 문제를 해결하기 위해 의존성을 controller가 service, facade를 의존하게 하여 controller에 변경에 영향을 최소화함.

### 고민해볼 사항
1. reviewFacadeDto에 User가 생겨 SRP가 잘 지켜지지 않은 코드가 된 것 같음.
2. User에 변경이 생길 시 영향이 갈 것으로 예상이 됨.

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
<!-- 없으면 없음으로 표기  -->
없음

## 📊 테스트
- [X] 테스트 코드
- 성공케이스만 작성.
- controller, facade, service에 맞추어 테스트 변경 및 추가.
- given에 추가한 모든 데이터를 검증.