### PR TITLE
모집게시글 조회 컨트롤러 코드 리펙토링, 조회시 Lazy 로딩에서 Eager로 수정해서 조회되지 않던 문제 해결.

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/post/controller/PostController.java
+++ b/travel/src/main/java/com/zerobase/travel/post/controller/PostController.java
@@ -96,57 +96,11 @@ public class PostController {
         @RequestParam(required = false) String mbti,
         @PageableDefault(size = 8, sort = "postId", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        // 검색 기준 설정
-        PostSearchCriteria criteria = new PostSearchCriteria();
-        criteria.setTitle(title);
-        criteria.setContent(content);
 
-        if (continent != null && !continent.isEmpty()) {
-            try {
-                criteria.setContinent(Enum.valueOf(Continent.class, continent.toUpperCase()));
-            } catch (IllegalArgumentException e) {
-                log.error("Invalid continent value: {}", continent);
-                throw new BizException(INVALID_CONTINENT_VALUE);
-            }
-        }
-
-        if (country != null && !country.isEmpty()) {
-            String countryUpper = country.toUpperCase();
-            Set<Country> representativeCountries = RepresentativeCountries.ALL_REPRESENTATIVE_COUNTRIES;
-            if (representativeCountries.stream().anyMatch(c -> c.name().equals(countryUpper))) {
-                try {
-                    criteria.setCountry(Enum.valueOf(Country.class, countryUpper));
-                } catch (IllegalArgumentException e) {
-                    log.error("Invalid country value: {}", country);
-                    throw new BizException(INVALID_COUNTRY_VALUE);
-                }
-            } else {
-                // "기타" 국가로 간주
-                criteria.setOthers(true);
-            }
-        }
-
-        if (mbti != null && !mbti.isEmpty()) {
-            try {
-                criteria.setMbti(Enum.valueOf(com.zerobase.travel.post.type.MBTI.class, mbti.toUpperCase()));
-            } catch (IllegalArgumentException e) {
-                log.error("Invalid MBTI value: {}", mbti);
-                throw new BizException(INVALID_MBTI_VALUE);
-            }
-        }
-
-        // 검색 수행
-        Page<ResponsePostsDTO> postPage = postService.searchPosts(criteria, pageable);
-
-        // PagedResponseDTO로 변환
-        PagedResponseDTO<ResponsePostsDTO> pagedResponse = PagedResponseDTO.<ResponsePostsDTO>builder()
-            .content(postPage.getContent())
-            .pageNumber(postPage.getNumber())
-            .pageSize(postPage.getSize())
-            .totalElements(postPage.getTotalElements())
-            .totalPages(postPage.getTotalPages())
-            .last(postPage.isLast())
-            .build();
+        // 검색 수행: 서비스 계층으로 요청 전달
+        PagedResponseDTO<ResponsePostsDTO> pagedResponse = postService.searchPosts(
+            title, content, continent, country, mbti, pageable
+        );
 
         return ResponseEntity.status(OK).body(ResponseMessage.success(pagedResponse));
     }

--- a/travel/src/main/java/com/zerobase/travel/post/entity/DayEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/DayEntity.java
@@ -43,13 +43,13 @@ public class DayEntity {
 
     // Day와 DayDetail 간의 연관관계 설정
     @OrderColumn(name = "order_number")
-    @OneToMany(mappedBy = "day", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "day", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @Builder.Default
     private List<DayDetailEntity> dayDetails = new ArrayList<>();
 
     // Day와 ItineraryVisit 간의 연관관계 설정
     @OrderColumn(name = "order_number")
-    @OneToMany(mappedBy = "day", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "day", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @Builder.Default
     private List<ItineraryVisitEntity> itineraryVisits = new ArrayList<>();
 

--- a/travel/src/main/java/com/zerobase/travel/post/entity/PostEntity.java
+++ b/travel/src/main/java/com/zerobase/travel/post/entity/PostEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -104,7 +105,7 @@ public class PostEntity {
     private PostStatus status;
 
     // Post와 Day 간의 연관관계 설정
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @Builder.Default
     private List<DayEntity> days = new ArrayList<>();
 


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
Hibernate에서 **LazyInitializationException**이 발생하여 지연 로딩된 컬렉션(`dayDetails`, `itineraryVisits`)을 조회할 수 없는 문제가 발생했습니다. 이로 인해 관련 데이터를 포함한 응답 생성이 실패하였으며, 컨트롤러에 로직이 집중되어 있어 가독성과 유지보수성에도 문제가 있었습니다.

---

## 🔑 PR에서 핵심적으로 변경된 사항

### **AS-IS**
- **LazyInitializationException 문제**
  - `fetch = FetchType.LAZY`로 설정된 연관 컬렉션(`dayDetails`, `itineraryVisits`)을 접근하려다 Hibernate 세션이 닫혀 예외가 발생.
- **컨트롤러에 로직 집중**
  - `PostController.searchPosts`에서 `PostSearchCriteria` 설정 및 검증, 서비스 호출 등의 로직이 혼재되어 코드 가독성이 떨어짐.

### **TO-BE**
- **LazyInitializationException 해결**
  - `dayDetails`, `itineraryVisits`의 `fetch` 전략을 `FetchType.LAZY`에서 **`FetchType.EAGER`**로 변경.
  - 필요한 연관 데이터를 즉시 로딩하여 LazyInitializationException 방지.
- **컨트롤러 리팩토링**
  - 검색 조건 설정 로직(`PostSearchCriteria` 구성)과 페이징 설정을 컨트롤러에서 서비스로 이동.
  - 컨트롤러는 요청 데이터를 단순히 서비스로 전달하고 결과만 반환하도록 설계하여 가독성과 유지보수성을 개선.

---

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
- 서비스 계층에서 검색 조건 검증 및 초기화를 담당하도록 설계 변경.

---

이번 PR을 통해 **Hibernate 지연 로딩 문제를 해결**하고, **컨트롤러와 서비스의 역할을 분리**하여 코드 개선.