### PR TITLE
feat) 참여 및 커뮤니티 조회시 유저 정보 추가

### DIFF
--- a/travel/src/main/java/com/zerobase/travel/communities/type/ResponseCommunityDto.java
+++ b/travel/src/main/java/com/zerobase/travel/communities/type/ResponseCommunityDto.java
@@ -1,7 +1,7 @@
 package com.zerobase.travel.communities.type;
 
-import com.zerobase.travel.typeCommon.Continent;
-import com.zerobase.travel.typeCommon.Country;
+import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
+import com.zerobase.travel.post.type.MBTI;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -19,10 +19,29 @@ public class ResponseCommunityDto {
 
     private long communityId;
     private String userId;
+    private String nickname;
+    private MBTI mbti;
+    private String profileFile;
     private String title;
     private String content;
     private List<CommunityFileDto> files;
     private LocalDate createdAt;
+
+    public static ResponseCommunityDto fromEntity(
+        CommunityDto communityDto,List<CommunityFileDto> communityFileDtos,
+        UserInfoResponseDTO userinfoDto){
+        return ResponseCommunityDto.builder()
+            .communityId(communityDto.getCommunityId())
+            .userId(communityDto.getUserId())
+            .nickname(userinfoDto.getNickname())
+            .mbti(userinfoDto.getMbti())
+            .profileFile(userinfoDto.getFileAddress())
+            .title(communityDto.getTitle())
+            .content(communityDto.getContent())
+            .files(communityFileDtos)
+            .createdAt(communityDto.getCreatedAt())
+            .build();
+    }
 
     public static ResponseCommunityDto fromEntity(
         CommunityDto communityDto,List<CommunityFileDto> communityFileDtos){

--- a/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
+++ b/travel/src/main/java/com/zerobase/travel/controller/ParticipationController.java
@@ -2,8 +2,8 @@ package com.zerobase.travel.controller;
 
 import com.zerobase.travel.common.response.ResponseMessage;
 import com.zerobase.travel.dto.ParticipationDto;
+import com.zerobase.travel.dto.ReseponseParticipation;
 import com.zerobase.travel.dto.ResponseMyParticipationsDto;
-import com.zerobase.travel.dto.ResponseParticipationsByPostDto;
 import com.zerobase.travel.redis.PostLock;
 import com.zerobase.travel.service.ParticipationManagementService;
 import com.zerobase.travel.service.ParticipationService;
@@ -54,12 +54,12 @@ public class ParticipationController {
 
     // 참여자 조회시에 Status에 Join/joinready 상태의 유저 리스트 확인
     @GetMapping("{postId}/participations")
-    public ResponseEntity<ResponseMessage<List<ResponseParticipationsByPostDto>>> getParticipationsByPost(
+    public ResponseEntity<ResponseMessage<List<ReseponseParticipation>>> getParticipationsByPost(
         @PathVariable Long postId) {
         log.info("getParticipationsByPost controller start");
         return ResponseEntity.ok(
             ResponseMessage.success(
-                participationService.getParticipationsDtosAfterJoin(postId)));
+                participationManagementService.getParticipationsByPostIdAndStatusActive(postId)));
     }
 
     // 참여자 조회시에Join/joinready 상태의 자신의 참여 게시글 리스트 확인
@@ -72,7 +72,7 @@ public class ParticipationController {
                 participationService.getMyParticipationsStatusOfJoinAndJoinReady(userId)));
     }
 
-    // 참여자 조회시에Join/joinready 상태의 자신의 참여 게시글 리스트 확인
+    // 참여자 조회시에travelFinished 상태의 자신의 참여 게시글 리스트 확인
     @GetMapping("/participations/by-travelfinished")
     public ResponseEntity<ResponseMessage<List<ResponseMyParticipationsDto>>> getMyParticipationsStatusofTravelFinished(
         @RequestHeader("X-User-Id") String userId) {

--- a/travel/src/main/java/com/zerobase/travel/dto/ParticipationsByPostDto.java
+++ b/travel/src/main/java/com/zerobase/travel/dto/ParticipationsByPostDto.java
@@ -12,15 +12,15 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ResponseParticipationsByPostDto {
+public class ParticipationsByPostDto {
     private Long participationId;
     private Long postId;
     private String userId;
 
 
 
-    public static ResponseParticipationsByPostDto fromEntity(ParticipationEntity participationEntity) {
-        return ResponseParticipationsByPostDto.builder()
+    public static ParticipationsByPostDto fromEntity(ParticipationEntity participationEntity) {
+        return ParticipationsByPostDto.builder()
             .participationId(participationEntity.getParticipationId())
             .postId(participationEntity.getPostEntity().getPostId())
             .userId(participationEntity.getUserId())

--- a/travel/src/main/java/com/zerobase/travel/dto/ReseponseParticipation.java
+++ b/travel/src/main/java/com/zerobase/travel/dto/ReseponseParticipation.java
@@ -1,0 +1,35 @@
+package com.zerobase.travel.dto;
+
+import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
+import com.zerobase.travel.post.type.MBTI;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ReseponseParticipation {
+    private Long participationId;
+    private Long postId;
+    private String userId;
+    private String nickname;
+    private MBTI mbti;
+    private String profileFile;
+
+
+    public static ReseponseParticipation fromDtos( ParticipationsByPostDto participationsByPostDto ,UserInfoResponseDTO userInfoResponseDTO){
+        return ReseponseParticipation.builder()
+            .participationId(participationsByPostDto.getParticipationId())
+            .postId(participationsByPostDto.getPostId())
+            .userId(participationsByPostDto.getUserId())
+            .nickname(userInfoResponseDTO.getNickname())
+            .mbti(userInfoResponseDTO.getMbti())
+            .profileFile(userInfoResponseDTO.getFileAddress())
+            .build();
+
+    }
+
+}

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationManagementService.java
@@ -4,10 +4,12 @@ import com.zerobase.travel.api.PayApi;
 import com.zerobase.travel.communities.type.CustomException;
 import com.zerobase.travel.communities.type.ErrorCode;
 import com.zerobase.travel.dto.ParticipationDto;
+import com.zerobase.travel.dto.ParticipationsByPostDto;
+import com.zerobase.travel.dto.ReseponseParticipation;
 import com.zerobase.travel.entity.ParticipationEntity;
-import com.zerobase.travel.post.entity.PostEntity;
+import com.zerobase.travel.post.dto.response.UserInfoResponseDTO;
+import com.zerobase.travel.post.entity.UserClient;
 import com.zerobase.travel.post.service.PostService;
-import com.zerobase.travel.redis.PostLock;
 import com.zerobase.travel.type.RatingStatus;
 import java.time.LocalDate;
 import java.util.List;
@@ -50,6 +52,7 @@ public class ParticipationManagementService {
     private final ParticipationService participationService;
     private final PayApi payApi;
     private final PostService postService;
+    private final UserClient userClient;
 
 
     private final int DEPOSIT_RETURN_DATE_DEFAULT = 30;
@@ -230,4 +233,18 @@ public class ParticipationManagementService {
     }
 
 
+    public List<ReseponseParticipation>  getParticipationsByPostIdAndStatusActive(long postId) {
+
+        log.info("service getParticipationsStatusOfJoinAndJoin");
+
+        List<ParticipationsByPostDto> participationsByPostDtos = participationService.getParticipationsByPostIdAndStatusActive(
+            postId);
+
+        List<ReseponseParticipation> reponseParticipations = participationsByPostDtos.stream()
+            .map(e -> ReseponseParticipation.fromDtos(e,
+                userClient.searchUserInfo("userId", e.getUserId().toString()).getData())
+            ).toList();
+
+        return reponseParticipations;
+    }
 }

--- a/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
+++ b/travel/src/main/java/com/zerobase/travel/service/ParticipationService.java
@@ -5,7 +5,7 @@ import com.zerobase.travel.communities.type.CustomException;
 import com.zerobase.travel.communities.type.ErrorCode;
 import com.zerobase.travel.dto.ResponseMyParticipationsDto;
 import com.zerobase.travel.dto.ParticipationDto;
-import com.zerobase.travel.dto.ResponseParticipationsByPostDto;
+import com.zerobase.travel.dto.ParticipationsByPostDto;
 import com.zerobase.travel.entity.ParticipationEntity;
 import com.zerobase.travel.exception.BizException;
 import com.zerobase.travel.exception.errorcode.ParticipationErrorCode;
@@ -270,7 +270,7 @@ public class ParticipationService {
 
 
     // 현재 여행을 참여하고 있는 복수 인원리스트 반환
-    public List<ResponseParticipationsByPostDto> getParticipationsDtosAfterJoin(
+    public List<ParticipationsByPostDto> getParticipationsByPostIdAndStatusActive(
         Long postId) {
         log.info("service getParticipationsStatusOfJoinAndJoin");
 
@@ -279,8 +279,10 @@ public class ParticipationService {
             postId,
             List.of(ParticipationStatus.JOIN, ParticipationStatus.JOIN_READY,ParticipationStatus.TRAVEL_FINISHED));
 
+
+
         return participationEntities.stream()
-            .map(ResponseParticipationsByPostDto::fromEntity).toList();
+            .map(ParticipationsByPostDto::fromEntity).toList();
     }
 
 

--- a/travel/src/test/java/com/zerobase/travel/communities/controller/CommunityControllerTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/controller/CommunityControllerTest.java
@@ -20,8 +20,6 @@ import com.zerobase.travel.communities.service.CommunityManagementService;
 import com.zerobase.travel.communities.type.RequestUpdateCommunity;
 import com.zerobase.travel.communities.type.ResponseCommunityDto;
 import com.zerobase.travel.post.dto.response.PagedResponseDTO;
-import com.zerobase.travel.typeCommon.Continent;
-import com.zerobase.travel.typeCommon.Country;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +67,7 @@ class CommunityControllerTest {
             .userId(SAMPLE_USER_ID)
             .title("Sample Community")
             .content("Sample content")
-            .files(Collections.emptyList())
+            .communityFiles(Collections.emptyList())
             .build();
     }
 

--- a/travel/src/test/java/com/zerobase/travel/communities/service/CommunityManagementServiceTest.java
+++ b/travel/src/test/java/com/zerobase/travel/communities/service/CommunityManagementServiceTest.java
@@ -70,7 +70,7 @@ class CommunityManagementServiceTest {
         // Then
         assertThat(response.getCommunityId()).isEqualTo(1L);
         assertThat(response.getTitle()).isEqualTo("Sample Title");
-        assertThat(response.getFiles()).hasSize(2);
+        assertThat(response.getCommunityFiles()).hasSize(2);
 
         verify(communityService, times(1)).createPost(any(), any(),  eq("user1"));
         verify(communityFileService, times(1)).saveFiles(anyLong(), any());
@@ -90,7 +90,7 @@ class CommunityManagementServiceTest {
         // Then
         assertThat(response.getContent()).hasSize(1);
         assertThat(response.getContent().get(0).getTitle()).isEqualTo("Sample Title");
-        assertThat(response.getContent().get(0).getFiles()).hasSize(2);
+        assertThat(response.getContent().get(0).getCommunityFiles()).hasSize(2);
 
         verify(communityService, times(1)).getPosts(pageable);
         verify(communityFileService, times(1)).getFiles(anyLong());
@@ -109,7 +109,7 @@ class CommunityManagementServiceTest {
         // Then
         assertThat(response.getCommunityId()).isEqualTo(1L);
         assertThat(response.getTitle()).isEqualTo("Sample Title");
-        assertThat(response.getFiles()).hasSize(2);
+        assertThat(response.getCommunityFiles()).hasSize(2);
 
         verify(communityService, times(1)).getPost(communityId);
         verify(communityFileService, times(1)).getFiles(communityId);
@@ -165,7 +165,7 @@ class CommunityManagementServiceTest {
         // Then
         assertThat(response.getTitle()).isEqualTo("Updated Title");
         assertThat(response.getContent()).isEqualTo("Updated Content");
-        assertThat(response.getFiles()).hasSize(2);
+        assertThat(response.getCommunityFiles()).hasSize(2);
 
         verify(communityService, times(1)).updatePost(anyLong(), any(), any(), eq("user1"));
         verify(communityFileService, times(1)).deleteAllByCommunityId(anyLong());


### PR DESCRIPTION
## 🔍 PR을 통해 해결하려는 문제
FE요청에 따라 커뮤니티 및 참여정보 조회시 유저의 프로필 정보 추가
이를 통해, BE에서 통합된 정보를 내려주어 FE 측에서 API 호출을 최소화시킴

## 🔑 PR에서 핵심적으로 변경된 사항
**AS-IS**
기존 커뮤니티 및 참여정보 조회시 유저의 userID만 제공

**TO-BE**
userID 뿐만 아니라 userMbti, nickname 등 프로필의 정보를 추가하여 발송

## 📄 핵심 변경 사항 외에 추가적으로 변경된 부분
## 📊 테스트
- [x] API 테스트 
